### PR TITLE
Implicit fallthrough fix

### DIFF
--- a/src/dlangui/widgets/widget.d
+++ b/src/dlangui/widgets/widget.d
@@ -660,6 +660,7 @@ class Widget {
             case KeyCode.DOWN:
                 if (flags == 0)
                     direction = FocusMovement.Down;
+                break;
             case KeyCode.TAB:
                 if (flags == 0)
                     direction = FocusMovement.Next;


### PR DESCRIPTION
Add a missing `break` in widgets/widget.d
