### PR TITLE
new font path

### DIFF
--- a/src/dlangui/platforms/sdl/sdlapp.d
+++ b/src/dlangui/platforms/sdl/sdlapp.d
@@ -1255,6 +1255,7 @@ version (Windows) {
 		ft.registerFonts("/usr/share/fonts/truetype/dejavu/");
 		ft.registerFonts("/usr/share/fonts/TTF/");
 		ft.registerFonts("/usr/share/fonts/dejavu/");
+		ft.registerFonts("/usr/share/fonts/truetype/ttf-dejavu/"); // let it compile on Debian Wheezy
         version(OSX) {
             ft.registerFont("/Library/Fonts/Arial.ttf", FontFamily.SansSerif, "Arial", false, FontWeight.Normal);
             ft.registerFont("/Library/Fonts/Arial Bold.ttf", FontFamily.SansSerif, "Arial", false, FontWeight.Bold);


### PR DESCRIPTION
registered a font path so dlangide will compile on Debian Wheezy without hacks

looking into fontconfig, never used it before 