### PR TITLE
Fix OpenGL in OSX by removing variables named 'texture'.

### DIFF
--- a/src/dlangui/graphics/glsupport.d
+++ b/src/dlangui/graphics/glsupport.d
@@ -85,7 +85,7 @@ class GLProgram {
     }
     
     private void compatibilityFixes(ref char[] code, GLuint type) {
-        //if (glslversionInt < 150)
+        if (glslversionInt < 150)
             code = replace(code, " texture(", " texture2D(");
     }
     
@@ -356,13 +356,13 @@ class TextureProgram : SolidFillProgram {
     }
     @property override string fragmentSource() {
         return q{
-            uniform sampler2D texture;
+            uniform sampler2D tex;
             in vec4 col;
             in vec4 texc;
             out vec4 outColor;
             void main(void)
             {
-                outColor = texture(texture, texc.st) * col;
+                outColor = texture(tex, texc.st) * col;
             }
         };
     }
@@ -469,13 +469,13 @@ class FontProgram : SolidFillProgram {
     }
     @property override string fragmentSource() {
         return q{
-            uniform sampler2D texture;
+            uniform sampler2D tex;
             in vec4 col;
             in vec4 texc;
             out vec4 outColor;
             void main(void)
             {
-                outColor = texture(texture, texc.st) * col;
+                outColor = texture(tex, texc.st) * col;
             }
         };
     }


### PR DESCRIPTION
Adds back the check for if glslversion < 150 for other platforms (texture2D is deprecated, so replacing texture with texture2D will cause issues on some platforms like OSX) and renames the texture variables to tex in order to prevent conflicts with texture(). This fixes OSX and continues to work on Windows.