### PR TITLE
Make handleAction not protected

### DIFF
--- a/src/dlangui/widgets/editors.d
+++ b/src/dlangui/widgets/editors.d
@@ -1564,7 +1564,7 @@ class EditLine : EditWidgetBase {
         measuredContent(parentWidth, parentHeight, _measuredTextSize.x + _leftPaneWidth, _measuredTextSize.y);
     }
 
-	override protected bool handleAction(const Action a) {
+	override bool handleAction(const Action a) {
 		switch (a.id) {
 			case EditorActions.InsertNewLine:
 			case EditorActions.PrependNewLine:


### PR DESCRIPTION
Useful to send EditorActions for tasks such as selecting all text from other classes.