### PR TITLE
fix implicit convert at src/dlangui/core/parser.d

### DIFF
--- a/src/dlangui/core/parser.d
+++ b/src/dlangui/core/parser.d
@@ -159,7 +159,7 @@ class Tokenizer {
         _filename = filename;
         _lines = LineStream.create(source, filename);
         _lineText = _lines.readLine();
-        _len = _lineText.length;
+        _len = cast(int)_lineText.length;
         _line = 0;
         _pos = 0;
         _prevChar = 0;
@@ -193,7 +193,7 @@ class Tokenizer {
             _prevChar = EOF_CHAR;
         else {
             _lineText = _lines.readLine();
-            _len = _lineText.length;
+            _len = cast(int)_lineText.length;
             _line++;
             _pos = 0;
             _prevChar = EOL_CHAR;


### PR DESCRIPTION
When I tried building example1, DMD showed these errors.

Erros:
src/dlangui/core/parser.d(162): Error: cannot implicitly convert expression (this._lineText.length) of type ulong to int
src/dlangui/core/parser.d(196): Error: cannot implicitly convert expression (this._lineText.length) of type ulong to int

I fixed these bugs as follows.

Original Code(both of these lines):
```d
_len = _lineText.length;
```
Fixed Core(both of these lines):
```d
_len = cast(int)_lineText.length;
```

My envrionments:
  OS X Yosemite(10.10.2)
  dmd v2.066