### PR TITLE
Fix scrollbar of FileDialog not updating

### DIFF
--- a/src/dlangui/dialogs/filedlg.d
+++ b/src/dlangui/dialogs/filedlg.d
@@ -227,6 +227,9 @@ class FileDialog : Dialog, CustomGridCellAdapter {
             _fileList.setCellText(2, i, toUTF32(sz));
             _fileList.setCellText(3, i, toUTF32(date));
         }
+        if(_fileList.height > 0)
+            _fileList.scrollTo(0, 0);
+
         _fileList.autoFitColumnWidths();
         _fileList.fillColumnWidth(1);
         if (selectionIndex >= 0)


### PR DESCRIPTION
If you change the opened directory in the FileDialog and opened
a directory with enough contents to require a scrollbar, the
scrollbar would not show up until you first scrolled. This commit
fixes this by updating the scrollbar whenever the displayed
directory of the FileDialog changes.