### PR TITLE
fix build error at graphics/fonts.d

### DIFF
--- a/src/dlangui/graphics/fonts.d
+++ b/src/dlangui/graphics/fonts.d
@@ -855,11 +855,11 @@ struct GlyphCache
 // maxv is 65 for win32 fonts, 256 for freetype
 import std.math;
 //---------------------------------
-struct glyph_gamma_table(int maxv = 65)
+class glyph_gamma_table(int maxv = 65)
 {
     this(double gammaValue = 1.0)
     {
-        gamma = gammaValue;
+        gamma(gammaValue);
     }
     @property double gamma() { return _gamma; }
     @property void gamma(double g) {
@@ -890,6 +890,6 @@ private:
 __gshared glyph_gamma_table!65 _gamma65;
 __gshared glyph_gamma_table!256 _gamma256;
 __gshared static this() {
-    _gamma65 = glyph_gamma_table!65(1.0);
-    _gamma256 = glyph_gamma_table!256(1.0);
+    _gamma65 = new glyph_gamma_table!65(1.0);
+    _gamma256 = new glyph_gamma_table!256(1.0);
 }


### PR DESCRIPTION
D does not allow to declare some default constructors for struct.
It is because that, unfortunately, your code does not be permitted in D's structure.

Correct Code:

```D
import std.stdio;
struct T{
    this(int v = 2){
          writeln(v);
    }
}

void main(){
    T s = T(1);
}
```

However, following code is not permitted.

```D
import std.stdio;
struct T{
    this(int v = 2){
          writeln(v);
    }
}

void main(){
    T t; // <- This definition occur build error.
         // This definition call default constructor such as this() but T does not have this().
    T s = T(30);
}
```

That's why your following code dose not permitted.

```D
struct glyph_gamma_table(int maxv = 65)
{
      this(double gammaValue = 1.0)
      {
            gamma = gammaValue;
      }
      //...

}

__gshared glyph_gamma_table!65 _gamma65;// <- calling this() !!!!!!
__gshared glyph_gamma_table!256 _gamma256;// <- calling this() !!!!!
```

Fix this problem by using a class instead of struct.

By the way I might found your miss.
Your code is:

```D
    gamma = gammaValue;
```

But this is not properly in this place, I think.
I guess that you intended to write as follows.

```D
    gamma(gammaValue);
```

I fixed as above.