### PR TITLE
minor improvement for file-dialog

### DIFF
--- a/src/dlangui/dialogs/filedlg.d
+++ b/src/dlangui/dialogs/filedlg.d
@@ -368,6 +368,10 @@ class FileDialog : Dialog, CustomGridCellAdapter {
                     result.stringParam = _filename;
                 close(result);
                 return true;
+            } else if (_filename.length == 0){
+                 auto row = _fileList.row();
+                 onItemActivated(row);
+                 return true;
             }
         }
         return super.handleAction(action);


### PR DESCRIPTION
if the user selects no file and press the open button:
 the dialog will (instead of closing itself) now open the selected directory