### PR TITLE
Rename `init` to `initialize`

### DIFF
--- a/examples/dmledit/src/dmledit.d
+++ b/examples/dmledit/src/dmledit.d
@@ -96,9 +96,9 @@ class EditFrame : AppFrame {
 
     MenuItem mainMenuItems;
 
-    override protected void init() {
+    override protected void initialize() {
         _appName = "DMLEdit";
-        super.init();
+        super.initialize();
         updatePreview();
     }
 

--- a/examples/spreadsheet/src/spreadsheetapp.d
+++ b/examples/spreadsheet/src/spreadsheetapp.d
@@ -46,9 +46,9 @@ class EditFrame : AppFrame {
 
     MenuItem mainMenuItems;
 
-    override protected void init() {
+    override protected void initialize() {
         _appName = "DlangUISpreadSheet";
-        super.init();
+        super.initialize();
     }
 
     /// create main menu

--- a/examples/tetris/src/gui.d
+++ b/examples/tetris/src/gui.d
@@ -264,7 +264,7 @@ class CupWidget : Widget {
     /// start new game
     void newGame() {
         setLevel(1);
-        init(_cols, _rows);
+        initialize(_cols, _rows);
         _cup.dropNextFigure();
         setCupState(CupState.NewFigure);
         if (window && _gameOverPopup) {
@@ -278,8 +278,8 @@ class CupWidget : Widget {
     }
 
     /// init cup
-    void init(int cols, int rows) {
-        _cup.init(cols, rows);
+    void initialize(int cols, int rows) {
+        _cup.initialize(cols, rows);
         _cols = cols;
         _rows = rows;
     }

--- a/examples/tetris/src/model.d
+++ b/examples/tetris/src/model.d
@@ -205,7 +205,7 @@ struct Cup {
         return _rows;
     }
     /// inits empty cup of specified size
-    void init(int cols, int rows) {
+    void initialize(int cols, int rows) {
         _cols = cols;
         _rows = rows;
         _cup = new int[_cols * _rows];

--- a/src/dlangui/core/dom.d
+++ b/src/dlangui/core/dom.d
@@ -249,9 +249,9 @@ class Document : Element {
 public:
     this() {
         super(null, 0, 0);
-        _elemIds.init!Tag();
-        _attrIds.init!Attr();
-        _nsIds.init!Ns();
+        _elemIds.initialize!Tag();
+        _attrIds.initialize!Attr();
+        _nsIds.initialize!Ns();
         _document = this;
     }
     /// create text node
@@ -348,7 +348,7 @@ private string removeTrailingUnderscore(string s) {
 /// String identifier to Id map - for interning strings
 struct IdentMap(ident_t) {
     /// initialize with elements of enum
-    void init(E)() if (is(E == enum)) {
+    void initialize(E)() if (is(E == enum)) {
         foreach(member; EnumMembers!E) {
             static if (member.to!int > 0) {
                 //pragma(msg, "interning string '" ~ removeTrailingUnderscore(member.to!string) ~ "' for " ~ E.stringof);
@@ -426,7 +426,7 @@ unittest {
     import std.algorithm : equal;
     //import std.stdio;
     IdentMap!(elem_id) map;
-    map.init!Tag();
+    map.initialize!Tag();
     //writeln("running DOM unit test");
     assert(map["pre"] == Tag.pre);
     assert(map["body"] == Tag.body_);

--- a/src/dlangui/core/settings.d
+++ b/src/dlangui/core/settings.d
@@ -1566,7 +1566,7 @@ final class Setting {
     private static struct JsonParser {
         string json;
         int pos;
-        void init(string s) {
+        void initialize(string s) {
             json = s;
             pos = 0;
         }
@@ -1897,7 +1897,7 @@ final class Setting {
     void parseJSON(string s) {
         clear(SettingType.NULL);
         JsonParser parser;
-        parser.init(s);
+        parser.initialize(s);
         parseJSON(parser);
     }
 

--- a/src/dlangui/core/textsource.d
+++ b/src/dlangui/core/textsource.d
@@ -55,7 +55,7 @@ class ArraySourceLines : SourceLines {
     }
 
     this(dstring[] lines, SourceFile file, uint firstLine = 0) {
-        init(lines, file, firstLine);
+        initialize(lines, file, firstLine);
     }
 
     this(string code, string filename) {
@@ -70,7 +70,7 @@ class ArraySourceLines : SourceLines {
         _file = null;
     }
 
-    void init(dstring[] lines, SourceFile file, uint firstLine = 0) {
+    void initialize(dstring[] lines, SourceFile file, uint firstLine = 0) {
         _lines = lines;
         _firstLine = firstLine;
         _line = 0;

--- a/src/dlangui/dialogs/dialog.d
+++ b/src/dlangui/dialogs/dialog.d
@@ -151,7 +151,7 @@ class Dialog : VerticalLayout {
     }
 
     /// override to implement creation of dialog controls
-    void init() {
+    void initialize() {
     }
 
     /** Notify about dialog result, and then close dialog.
@@ -177,7 +177,7 @@ class Dialog : VerticalLayout {
 
     /// shows dialog
     void show() {
-        init();
+        initialize();
         uint wflags = 0;
         if (_flags & DialogFlag.Modal)
             wflags |= WindowFlag.Modal;

--- a/src/dlangui/dialogs/filedlg.d
+++ b/src/dlangui/dialogs/filedlg.d
@@ -383,7 +383,7 @@ class FileDialog : Dialog, CustomGridCellAdapter {
     }
 
     /// override to implement creation of dialog controls
-    override void init() {
+    override void initialize() {
         _roots = getRootPaths;
 
         layoutWidth(FILL_PARENT).layoutHeight(FILL_PARENT).minWidth(600);
@@ -582,7 +582,7 @@ class FilePathPanelButtons : WidgetGroupDefaultDrawing {
         layoutWidth = FILL_PARENT;
         clickable = true;
     }
-    protected void init(string path) {
+    protected void initialize(string path) {
         _path = path;
         _children.clear();
         string itemPath = path;
@@ -737,7 +737,7 @@ class FilePathPanel : FrameLayout {
     }
 
     @property void path(string value) {
-        _segments.init(value);
+        _segments.initialize(value);
         _edPath.text = toUTF32(value);
         _path = value;
         showChild(ID_SEGMENTS);

--- a/src/dlangui/dialogs/inputbox.d
+++ b/src/dlangui/dialogs/inputbox.d
@@ -30,7 +30,7 @@ class InputBox : Dialog {
         }
     }
     /// override to implement creation of dialog controls
-    override void init() {
+    override void initialize() {
         TextWidget msg = new MultilineTextWidget("msg", _message);
         padding(Rect(10, 10, 10, 10));
         msg.padding(Rect(10, 10, 10, 10));

--- a/src/dlangui/dialogs/msgbox.d
+++ b/src/dlangui/dialogs/msgbox.d
@@ -54,7 +54,7 @@ class MessageBox : Dialog {
         }
     }
     /// override to implement creation of dialog controls
-    override void init() {
+    override void initialize() {
         TextWidget msg = new MultilineTextWidget("msg", _message);
         padding(Rect(10, 10, 10, 10));
         msg.padding(Rect(10, 10, 10, 10));

--- a/src/dlangui/dialogs/settingsdialog.d
+++ b/src/dlangui/dialogs/settingsdialog.d
@@ -481,7 +481,7 @@ class SettingsDialog : Dialog {
     }
 
     /// override to implement creation of dialog controls
-    override void init() {
+    override void initialize() {
         minWidth(600).minHeight(400);
         _tree = new TreeWidget("prop_tree");
         _tree.styleId = STYLE_SETTINGS_TREE;

--- a/src/dlangui/dml/dmlhighlight.d
+++ b/src/dlangui/dml/dmlhighlight.d
@@ -35,7 +35,7 @@ class DMLSyntaxSupport : SyntaxSupport {
         dchar[] buf;
         int pos;
         bool reverse;
-        void init(bool reverse) {
+        void initialize(bool reverse) {
             this.reverse = reverse;
             pos = 0;
         }
@@ -146,7 +146,7 @@ class DMLSyntaxSupport : SyntaxSupport {
             return p;
         TextPosition startPos = p;
         int dir = isOpenBracket(ch) ? 1 : -1;
-        _bracketStack.init(dir < 0);
+        _bracketStack.initialize(dir < 0);
         _bracketStack.process(ch);
         for (;;) {
             ch = nextBracket(dir, p);

--- a/src/dlangui/graphics/colors.d
+++ b/src/dlangui/graphics/colors.d
@@ -109,7 +109,7 @@ ubyte rgbToGray(uint color) {
 
 // todo
 struct ColorTransformHandler {
-    void init(ref ColorTransform transform) {
+    void initialize(ref ColorTransform transform) {
 
     }
     uint transform(uint color) {

--- a/src/dlangui/platforms/windows/win32fonts.d
+++ b/src/dlangui/platforms/windows/win32fonts.d
@@ -498,15 +498,15 @@ class Win32FontManager : FontManager {
     this() {
         debug Log.i("Creating Win32FontManager");
         //instance = this;
-        init();
+        initialize();
     }
     ~this() {
         debug Log.i("Destroying Win32FontManager");
     }
 
     /// initialize font manager by enumerating of system fonts
-    bool init() {
-        debug Log.i("Win32FontManager.init()");
+    bool initialize() {
+        debug Log.i("Win32FontManager.initialize()");
         Win32ColorDrawBuf drawbuf = new Win32ColorDrawBuf(1,1);
         LOGFONTA lf;
         lf.lfCharSet = ANSI_CHARSET; //DEFAULT_CHARSET;

--- a/src/dlangui/widgets/appframe.d
+++ b/src/dlangui/widgets/appframe.d
@@ -85,7 +85,7 @@ class AppFrame : VerticalLayout, MenuItemClickHandler, MenuItemActionHandler {
         layoutWidth = FILL_PARENT;
         layoutHeight = FILL_PARENT;
         _appName = "dlangui";
-        init();
+        initialize();
     }
 
     protected string _appName;
@@ -227,7 +227,7 @@ class AppFrame : VerticalLayout, MenuItemClickHandler, MenuItemActionHandler {
         return super.findKeyAction(keyCode, flags);
     }
 
-    protected void init() {
+    protected void initialize() {
         _mainMenu = createMainMenu();
         _toolbarHost = createToolbars();
         _statusLine = createStatusLine();

--- a/src/dlangui/widgets/combobox.d
+++ b/src/dlangui/widgets/combobox.d
@@ -146,7 +146,7 @@ class ComboBoxBase : HorizontalLayout, OnClickHandler {
         _ownAdapter = ownAdapter;
         styleId = STYLE_COMBO_BOX;
         trackHover = true;
-        init();
+        initialize();
     }
 
     void setAdapter(ListAdapter adapter, bool ownAdapter = true) {
@@ -157,10 +157,10 @@ class ComboBoxBase : HorizontalLayout, OnClickHandler {
         }
         _adapter = adapter;
         _ownAdapter = ownAdapter;
-        init();
+        initialize();
     }
 
-    protected void init() {
+    protected void initialize() {
         _body = createSelectedItemWidget();
         _body.click = this;
         _button = createButton();
@@ -276,8 +276,8 @@ class ComboBox : ComboBoxBase {
         return super.selectedItemIndex(index);
     }
 
-    override void init() {
-        super.init();
+    override void initialize() {
+        super.initialize();
         _body.focusable = false;
         _body.clickable = true;
         focusable = true;
@@ -351,8 +351,8 @@ class ComboEdit : ComboBox {
         return res;
     }
 
-    override void init() {
-        super.init();
+    override void initialize() {
+        super.initialize();
         //focusable = false;
         //_body.focusable = true;
     }

--- a/src/dlangui/widgets/controls.d
+++ b/src/dlangui/widgets/controls.d
@@ -300,7 +300,7 @@ class ImageTextButton : HorizontalLayout {
         return this; 
     }
 
-    protected void init(string drawableId, UIString caption) {
+    protected void initialize(string drawableId, UIString caption) {
         styleId = STYLE_BUTTON;
         _icon = new ImageWidget("icon", drawableId);
         _icon.styleId = STYLE_BUTTON_IMAGE;
@@ -318,19 +318,19 @@ class ImageTextButton : HorizontalLayout {
     this(string ID = null, string drawableId = null, string textResourceId = null) {
         super(ID);
         UIString caption = textResourceId;
-        init(drawableId, caption);
+        initialize(drawableId, caption);
     }
 
     this(string ID, string drawableId, dstring rawText) {
         super(ID);
         UIString caption = rawText;
-        init(drawableId, caption);
+        initialize(drawableId, caption);
     }
 
     /// constructor from action
     this(const Action a) {
         super("imagetextbutton-action" ~ to!string(a.id));
-        init(a.iconId, a.labelValue);
+        initialize(a.iconId, a.labelValue);
         action = a;
     }
 
@@ -375,8 +375,8 @@ class CheckBox : ImageTextButton {
     this(string ID, UIString label) {
         super(ID, "btn_check", label);
     }
-    override protected void init(string drawableId, UIString caption) {
-        super.init(drawableId, caption);
+    override protected void initialize(string drawableId, UIString caption) {
+        super.initialize(drawableId, caption);
         styleId = STYLE_CHECKBOX;
         if (_icon)
             _icon.styleId = STYLE_CHECKBOX_IMAGE;
@@ -399,8 +399,8 @@ class RadioButton : ImageTextButton {
     this(string ID, dstring labelText) {
         super(ID, "btn_radio", labelText);
     }
-    override protected void init(string drawableId, UIString caption) {
-        super.init(drawableId, caption);
+    override protected void initialize(string drawableId, UIString caption) {
+        super.initialize(drawableId, caption);
         styleId = STYLE_RADIOBUTTON;
         if (_icon)
             _icon.styleId = STYLE_RADIOBUTTON_IMAGE;
@@ -443,10 +443,10 @@ class Button : Widget {
     /// empty parameter list constructor - for usage by factory
     this() {
         super(null);
-        init(UIString());
+        initialize(UIString());
     }
 
-    private void init(UIString label) {
+    private void initialize(UIString label) {
         styleId = STYLE_BUTTON;
         _text = label;
         clickable = true;
@@ -457,19 +457,19 @@ class Button : Widget {
     /// create with ID parameter
     this(string ID) {
         super(ID);
-        init(UIString());
+        initialize(UIString());
     }
     this(string ID, UIString label) {
         super(ID);
-        init(label);
+        initialize(label);
     }
     this(string ID, dstring label) {
         super(ID);
-        init(UIString(label));
+        initialize(UIString(label));
     }
     this(string ID, string labelResourceId) {
         super(ID);
-        init(UIString(labelResourceId));
+        initialize(UIString(labelResourceId));
     }
     /// constructor from action
     this(const Action a) {

--- a/src/dlangui/widgets/docks.d
+++ b/src/dlangui/widgets/docks.d
@@ -53,7 +53,7 @@ struct DockSpace {
     @property int space() { return _space; }
     protected int _minSpace;
     protected int _maxSpace;
-    ResizerWidget init(DockHost host, DockAlignment a) {
+    ResizerWidget initialize(DockHost host, DockAlignment a) {
         _host = host;
         _alignment = a;
         final switch (a) with(DockAlignment)
@@ -207,10 +207,10 @@ class DockHost : WidgetGroupDefaultDrawing {
     this() {
         super("DOCK_HOST");
         styleId = STYLE_DOCK_HOST;
-        addChild(_topSpace.init(this, DockAlignment.Top));
-        addChild(_bottomSpace.init(this, DockAlignment.Bottom));
-        addChild(_leftSpace.init(this, DockAlignment.Left));
-        addChild(_rightSpace.init(this, DockAlignment.Right));
+        addChild(_topSpace.initialize(this, DockAlignment.Top));
+        addChild(_bottomSpace.initialize(this, DockAlignment.Bottom));
+        addChild(_leftSpace.initialize(this, DockAlignment.Left));
+        addChild(_rightSpace.initialize(this, DockAlignment.Right));
     }
 
     protected DockWindow[] getDockedWindowList(DockAlignment alignType) {
@@ -323,8 +323,8 @@ class DockWindow : WindowFrame {
         super(ID);
     }
 
-    override protected void init() {
-        super.init();
+    override protected void initialize() {
+        super.initialize();
         _dockAlignment = DockAlignment.Right; // default alignment is right
     }
 

--- a/src/dlangui/widgets/layouts.d
+++ b/src/dlangui/widgets/layouts.d
@@ -690,7 +690,7 @@ class TableLayout : WidgetGroupDefaultDrawing {
         int minSize;
         int maxSize;
         int size;
-        void init(int index) {
+        void initialize(int index) {
             measuredSize = minSize = maxSize = layoutSize = size = 0;
             this.index = index;
         }
@@ -721,16 +721,16 @@ class TableLayout : WidgetGroupDefaultDrawing {
         protected int colCount;
         protected int rowCount;
 
-        void init(int cols, int rows) {
+        void initialize(int cols, int rows) {
             colCount = cols;
             rowCount = rows;
             _cells.length = cols * rows;
             _rows.length = rows;
             _cols.length = cols;
             for(int i = 0; i < rows; i++)
-                _rows[i].init(i);
+                _rows[i].initialize(i);
             for(int i = 0; i < cols; i++)
-                _cols[i].init(i);
+                _cols[i].initialize(i);
             for (int y = 0; y < rows; y++) {
                 for (int x = 0; x < cols; x++) {
                     cell(x, y).clear(x, y);
@@ -751,7 +751,7 @@ class TableLayout : WidgetGroupDefaultDrawing {
         }
 
         Point measure(Widget parent, int cc, int rc, int pwidth, int pheight) {
-            init(cc, rc);
+            initialize(cc, rc);
             for (int y = 0; y < rc; y++) {
                 for (int x = 0; x < cc; x++) {
                     int index = y * cc + x;

--- a/src/dlangui/widgets/statusline.d
+++ b/src/dlangui/widgets/statusline.d
@@ -107,9 +107,9 @@ class StatusLine : HorizontalLayout {
     this() {
         super("STATUS_LINE");
         styleId = STYLE_STATUS_LINE;
-        init();
+        initialize();
     }
-    void init() {
+    void initialize() {
         _defStatus = new TextWidget("STATUS_LINE_TEXT");
         _defStatus.layoutWidth(FILL_PARENT);
         _defStatus.text = "DLANGUI"d;

--- a/src/dlangui/widgets/winframe.d
+++ b/src/dlangui/widgets/winframe.d
@@ -44,7 +44,7 @@ class WindowFrame : VerticalLayout {
     this(string ID, bool showCloseButton = true) {
         super(ID);
         _showCloseButton = showCloseButton;
-        init();
+        initialize();
     }
 
     Signal!OnClickHandler closeButtonClick;
@@ -54,7 +54,7 @@ class WindowFrame : VerticalLayout {
         return true;
     }
 
-    protected void init() {
+    protected void initialize() {
 
         styleId = STYLE_DOCK_WINDOW;
 


### PR DESCRIPTION
`init` methods sometimes conflict with builtin `.init` property.

For example, `ElementType!(CheckBox[])` returns `void(string, UIString)` instead of `CheckBox` because `ElementType` try to use `CheckBox.init` property but it accidentally uses `CheckBox.init(string, UIString)`.

This request solves this issue by replacing `init` methods with `initialize` for all classes.