### PR TITLE
adds two import directories for linux in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,8 @@ Following settings are to be applied to all configurations of your new project (
         ../dlangui/deps/DerelictFT/source
         ../dlangui/deps/DerelictGL3/source
         ../dlangui/deps/DerelictUtil/source
+        ../dlangui/3rdparty
+        ../dlangui/3rdparty-extra
 
 Now you can build and run your project.
  


### PR DESCRIPTION
I was getting error `images.d(34,12): Error: module image is in file 'dimage/image.d' which cannot be read` without those imports. Thought others might also find it useful when following the readme.