### PR TITLE
Adds flag whether to destroy objects when removing all children from a widget

### DIFF
--- a/src/dlangui/core/collections.d
+++ b/src/dlangui/core/collections.d
@@ -324,9 +324,11 @@ struct ObjectList(T) {
         }
     }
     /** remove and destroy all items */
-    void clear() {
+	void clear(bool destroyObj = true) {
         for (int i = 0; i < _count; i++) {
-            destroy(_list[i]);
+			if(destroyObj) {
+				destroy(_list[i]);
+            }
             _list[i] = null;
         }
         _count = 0;

--- a/src/dlangui/widgets/widget.d
+++ b/src/dlangui/widgets/widget.d
@@ -1513,7 +1513,7 @@ public:
         _window = window; 
     }
 
-    void removeAllChildren() {
+    void removeAllChildren(bool destroyObj = true) {
         // override
     }
 
@@ -1648,8 +1648,8 @@ class WidgetGroup : Widget {
     /// returns index of widget in child list, -1 if passed widget is not a child of this widget
     override int childIndex(Widget item) { return _children.indexOf(item); }
 
-    override void removeAllChildren() {
-        _children.clear();
+	override void removeAllChildren(bool destroyObj = true) {
+        _children.clear(destroyObj);
     }
 
 }


### PR DESCRIPTION
Sometimes user might want to remove all children from a widget, but not destroy them. If removeAllChildren is called with "false", objects will not be destroyed. Flag is set to true by default.