### PR TITLE
Add method to recursively create missing directories

### DIFF
--- a/src/dlangui/core/files.d
+++ b/src/dlangui/core/files.d
@@ -358,6 +358,19 @@ string[] splitPath(string path) {
     return res;
 }
 
+/** Creates all directories that are missing in the specified path, e.g. given /home/user/dir1/dir2 if dir1 does not exist, creates both dir1 and dir2. */
+void createMissingDirs(string path) {
+    auto parts = splitPath(path);
+    auto partialPath = "";
+    foreach(part; parts) {
+        partialPath = appendPath(partialPath, part);
+        if(exists(partialPath))
+            continue;
+        else
+            mkdir(partialPath);
+    }
+}
+
 /// for executable name w/o path, find absolute path to executable
 string findExecutablePath(string executableName) {
     import std.string : split;


### PR DESCRIPTION
I often end up needing this functionality in many GUI applications anyways, so having this in DlangUI instead of DlangIDE might be a good thing. If this shouldn't be here, this should probably be moved to DlangIDE?

Also see buggins/dlangide#103