### PR TITLE
Fix infinite recursion loop

### DIFF
--- a/src/dlangui/widgets/lists.d
+++ b/src/dlangui/widgets/lists.d
@@ -434,7 +434,7 @@ class StringListAdapter : StringListAdapterBase {
 
     /// reset one or more list item's state flags, returns updated state
     override uint resetItemState(int index, uint flags) {
-        uint res = resetItemState(index, flags);
+        uint res = super.resetItemState(index, flags);
         if (_widget !is null && _lastItemIndex == index)
             _widget.state = res;
         return res;


### PR DESCRIPTION
resetItemState was unconditionally recursive because it calls itself
instead of the base classes implementation.

Pretty sure that was just a simple oversight in 9f9c1d614f494b0064e0b690576ba64fea580903.