### PR TITLE
Change Textbox Behaviour

### DIFF
--- a/src/dlangui/core/types.d
+++ b/src/dlangui/core/types.d
@@ -467,6 +467,8 @@ enum State : uint {
     WindowFocused = 256,
     /// widget is default control for form (should be focused when window gains focus first time)
     Default = 512, // widget is default for form (e.g. default button will be focused on show)
+    /// widget has been focused by keyboard navigation
+    KeyboardFocused = 1024,
     /// return state of parent instead of widget's state when requested
     Parent = 0x10000, // use parent's state
 }

--- a/src/dlangui/platforms/common/platform.d
+++ b/src/dlangui/platforms/common/platform.d
@@ -523,19 +523,22 @@ class Window : CustomEventTarget {
     }
 
     /// change focus to widget
-    Widget setFocus(Widget newFocus) {
+    Widget setFocus(Widget newFocus, FocusReason reason = FocusReason.Unspecified) {
         if (!isChild(_focusedWidget))
             _focusedWidget = null;
         Widget oldFocus = _focusedWidget;
+        auto targetState = State.Focused;
+        if(reason == FocusReason.TabFocus)
+            targetState = State.Focused | State.KeyboardFocused;
         if (oldFocus is newFocus)
             return oldFocus;
         if (oldFocus !is null)
-            oldFocus.resetState(State.Focused);
+            oldFocus.resetState(targetState);
         if (newFocus is null || isChild(newFocus)) {
             if (newFocus !is null) {
                 // when calling, setState(focused), window.focusedWidget is still previously focused widget
                 debug(DebugFocus) Log.d("new focus: ", newFocus.id);
-                newFocus.setState(State.Focused);
+                newFocus.setState(targetState);
             }
             _focusedWidget = newFocus;
             // after focus change, ask for actions update automatically

--- a/src/dlangui/widgets/lists.d
+++ b/src/dlangui/widgets/lists.d
@@ -732,7 +732,7 @@ class ListWidget : WidgetGroup, OnScrollHandler, OnAdapterChangeHandler {
     }
 
     /// override to handle focus changes
-    override protected void handleFocusChange(bool focused) {
+    override protected void handleFocusChange(bool focused, bool receivedFocusFromKeyboard = false) {
         updateSelectedItemFocus();
     }
 

--- a/src/dlangui/widgets/menu.d
+++ b/src/dlangui/widgets/menu.d
@@ -887,7 +887,7 @@ class MainMenu : MenuWidgetBase {
     }
 
     /// override to handle focus changes
-    override protected void handleFocusChange(bool focused) {
+    override protected void handleFocusChange(bool focused, bool receivedFocusFromKeyboard = false) {
         debug(DebugMenus) Log.d("menu ", id, "handling focus change to ", focused);
         if (focused && _openedPopup is null) {
             // activating!


### PR DESCRIPTION
Textboxes have slightly altered behaviour: Shift-clicking to move the
cursor creates a selection from the previous cursor position to the
new position.
Tabbing into an EditLine selects all its contents, tabbing out of an
EditLine deselects everything.

Not at all sure that the way I achieved the above behaviour is sane and good. The changes to focus handling don't sit too well with me. If there's concrete suggestions on how I can improve this, do tell, and if it's good enough then well, I guess here we go.