### PR TITLE
Fix bugs in Win32ColorDrawBuf, ColorDrawBuf and SimpleTextFormatter

### DIFF
--- a/src/dlangui/graphics/drawbuf.d
+++ b/src/dlangui/graphics/drawbuf.d
@@ -475,13 +475,16 @@ class ColorDrawBufBase : DrawBuf {
         }
     }
 
+	import std.container.array;
+
     /// Create mapping of source coordinates to destination coordinates, for resize.
-    private int[] createMap(int dst0, int dst1, int src0, int src1) {
+    private Array!int createMap(int dst0, int dst1, int src0, int src1, double k) {
         int dd = dst1 - dst0;
-        int sd = src1 - src0;
-        int[] res = new int[dd];
+        //int sd = src1 - src0;
+		Array!int res;
+		res.length = dd;
         foreach(int i; 0 .. dd)
-            res[i] = src0 + i * sd / dd;
+            res[i] = src0 + cast(int)(i * k);//sd / dd;
         return res;
     }
 
@@ -490,11 +493,14 @@ class ColorDrawBufBase : DrawBuf {
         //Log.d("drawRescaled ", dstrect, " <- ", srcrect);
         if (_alpha >= 254)
             return; // fully transparent - don't draw
+		double kx = cast(double)srcrect.width / dstrect.width;
+		double ky = cast(double)srcrect.height / dstrect.height;
         if (applyClipping(dstrect, srcrect)) {
-            int[] xmapArray = createMap(dstrect.left, dstrect.right, srcrect.left, srcrect.right);
-            int[] ymapArray = createMap(dstrect.top, dstrect.bottom, srcrect.top, srcrect.bottom);
-            int * xmap = xmapArray.ptr;
-            int * ymap = ymapArray.ptr;
+            auto xmapArray = createMap(dstrect.left, dstrect.right, srcrect.left, srcrect.right, kx);
+            auto ymapArray = createMap(dstrect.top, dstrect.bottom, srcrect.top, srcrect.bottom, ky);
+
+            int * xmap = &xmapArray[0];
+            int * ymap = &ymapArray[0];
             int dx = dstrect.width;
             int dy = dstrect.height;
             ColorDrawBufBase colorDrawBuf = cast(ColorDrawBufBase) src;

--- a/src/dlangui/graphics/fonts.d
+++ b/src/dlangui/graphics/fonts.d
@@ -502,8 +502,8 @@ struct SimpleTextFormatter {
                 if (ch == '\t' || ch == ' ') {
                     // track last word end
                     if (prevChar != '\t' && prevChar != ' ' && prevChar != 0) {
-                        lastWordEnd = i - 1;
-                        lastWordEndX = widths[i - 1];
+                        lastWordEnd = i;
+                        lastWordEndX = widths[i]; 
                     }
                     prevChar = ch;
                     continue;

--- a/src/dlangui/platforms/windows/win32drawbuf.d
+++ b/src/dlangui/platforms/windows/win32drawbuf.d
@@ -157,7 +157,7 @@ class Win32ColorDrawBuf : ColorDrawBufBase {
         int len = _dx * _dy;
         //for (int i = 0; i < len; i++)
         //    _pixels[i] = color;
-        _pixels[0 .. len - 1] = color;
+        _pixels[0 .. len] = color;
     }
     /// draw to win32 device context
     void drawTo(HDC dc, int x, int y) {


### PR DESCRIPTION
One indexing error in Win32ColorDrawBuf caused crashes when window was minimized.

Another off-by-one error in SimpleTextFormatter made line splitting wrong: last character of a word was sent to next line, so "word" was split to "wor\nd".

Also fixed a subtle bug with upscaling and clipping images: after clipping the ratio of source and destination sizes could be different from original intended ratio (you couldn't properly upscale image 2x if it was cropped to odd size).