### PR TITLE
minor improvement file dialog

### DIFF
--- a/src/dlangui/dialogs/filedlg.d
+++ b/src/dlangui/dialogs/filedlg.d
@@ -336,12 +336,11 @@ class FileDialog : Dialog, CustomGridCellAdapter {
     /// file list item selected
     protected void onItemSelected(int index) {
         DirEntry e = _entries[index];
+        string fname = e.name;
+        _edFilename.text = toUTF32(baseName(fname));
         if (e.isDir) {
-            _edFilename.text = ""d;
             _filename = "";
         } else if (e.isFile) {
-            string fname = e.name;
-            _edFilename.text = toUTF32(baseName(fname));
             _filename = fname;
         }
     }


### PR DESCRIPTION

![filedialog](https://cloud.githubusercontent.com/assets/10485658/13594808/4e4de398-e507-11e5-9515-0d8c196aa112.png)
show selected directory in textbox
this gives a better visual feedback to the user when selecting directories e.g. by mouse click.