### PR TITLE
new method to get selected text from editor

### DIFF
--- a/src/dlangui/widgets/editors.d
+++ b/src/dlangui/widgets/editors.d
@@ -1111,6 +1111,11 @@ class EditWidgetBase : ScrollWidgetBase, EditableContentListener, MenuItemAction
         return true;
     }
 
+    public dstring getSelectedText(){
+        dstring selectionText = concatDStrings(_content.rangeText(_selectionRange));
+        return selectionText;
+    }
+    
     protected bool removeRangeText(TextRange range) {
         if (range.empty)
             return false;
@@ -1310,13 +1315,13 @@ class EditWidgetBase : ScrollWidgetBase, EditableContentListener, MenuItemAction
                 return true;
             case Copy:
                 if (!_selectionRange.empty) {
-                    dstring selectionText = concatDStrings(_content.rangeText(_selectionRange));
+                    dstring selectionText = getSelectedText();
                     platform.setClipboardText(selectionText);
                 }
                 return true;
             case Cut:
                 if (!_selectionRange.empty) {
-                    dstring selectionText = concatDStrings(_content.rangeText(_selectionRange));
+                    dstring selectionText = getSelectedText();
                     platform.setClipboardText(selectionText);
                     if (readOnly)
                         return true;


### PR DESCRIPTION
public getter method to get current selected text from the editor.
used to avoid code duplication but more important for me i need it for get the selection so i can prefill search panel textbox in dlangide.