### PR TITLE
Tabs fixes

### DIFF
--- a/src/dlangui/core/logger.d
+++ b/src/dlangui/core/logger.d
@@ -144,7 +144,7 @@ class Log {
         if (logLevel >= level && logFile !is null && logFile.isOpen) {
             SysTime ts = Clock.currTime();
             logFile.writef("%04d-%02d-%02d %02d:%02d:%02d.%03d %s  ", ts.year, ts.month, ts.day, ts.hour, ts.minute, ts.second, ts.fracSecs.split!("msecs").msecs, logLevelName(level));
-            logFile.writeln(args);
+            logFile.writefln(args);
             logFile.flush();
         }
     }

--- a/src/dlangui/widgets/tabs.d
+++ b/src/dlangui/widgets/tabs.d
@@ -646,6 +646,7 @@ class TabHost : FrameLayout, TabHandler {
         assert(widget.id !is null, "ID for tab host page is mandatory");
         assert(_children.indexOf(id) == -1, "duplicate ID for tab host page");
         _tabControl.addTab(widget.id, label, iconId, enableCloseButton);
+        tabInitialization(widget);
         //widget.focusGroup = true; // doesn't allow move focus outside of tab content
         addChild(widget);
         return this;
@@ -656,9 +657,21 @@ class TabHost : FrameLayout, TabHandler {
         assert(widget.id !is null, "ID for tab host page is mandatory");
         assert(_children.indexOf(id) == -1, "duplicate ID for tab host page");
         _tabControl.addTab(widget.id, labelResourceId, iconId, enableCloseButton);
+        tabInitialization(widget);
         addChild(widget);
         return this;
     }
+
+    // handles initial tab selection & hides subsequently added tabs so
+    // they don't appear in the same frame
+    private void tabInitialization(Widget widget) {
+        if(_tabControl.selectedTabId is null) {
+            selectTab(_tabControl.tab(0).id,false);
+        } else {
+            widget.visibility = Visibility.Invisible;
+        }
+    }
+    
     /// select tab
     void selectTab(string ID, bool updateAccess) {
         int index = _tabControl.tabIndex(ID);

--- a/src/dlangui/widgets/tabs.d
+++ b/src/dlangui/widgets/tabs.d
@@ -557,6 +557,10 @@ class TabControl : WidgetGroupDefaultDrawing {
     }
 
     void selectTab(int index, bool updateAccess) {
+        if (index < 0 || index + 1 >= _children.count) {
+            Log.e("Tried to access tab out of bounds (index = %d, count = %d)",index,_children.count-1);
+            return;
+        }
         if (_children.get(index + 1).compareId(_selectedTabId))
             return; // already selected
         string previousSelectedTab = _selectedTabId;


### PR DESCRIPTION
There was a bug in the tab widget in which all the widgets from all tabs would initially appear as one big lump, unless app explicitly defined the initial tab to be shown (by using selectTab)

I changed it so that the first added tab will be selected as the default (user can still override it by using selectTab) and also widgets from subsequently added tabs are set to invisible.

Another change was fixing a crash when you would try to change to nonexisting tab using index value out of bounds. Error log message is printed instead.

I also modified the logger to use writefln for output instead for writeln, since it would allow formatted strings - or is there a specific reason for using plain writeln?
