### PR TITLE
Use invalidate instead of redraw added in commits dd0df51 and fed4712

### DIFF
--- a/src/dlangui/platforms/sdl/sdlapp.d
+++ b/src/dlangui/platforms/sdl/sdlapp.d
@@ -1057,7 +1057,7 @@ class SDLPlatform : Platform {
                             case SDL_WINDOWEVENT_EXPOSED:
                                 debug(DebugSDL) Log.d("SDL_WINDOWEVENT_EXPOSED");
                                 version(linux) {
-                                    w.redraw(); 
+                                    w.invalidate();
                                 }
                                 break;
                             case SDL_WINDOWEVENT_MOVED:
@@ -1072,7 +1072,7 @@ class SDLPlatform : Platform {
                             case SDL_WINDOWEVENT_RESTORED:
                                 debug(DebugSDL) Log.d("SDL_WINDOWEVENT_RESTORED");
                                 version(linux) { //not sure if needed on Windows or OSX. Also need to check on FreeBSD
-                                    w.redraw(); 
+                                    w.invalidate(); 
                                 }
                                 break;
                             case SDL_WINDOWEVENT_ENTER:


### PR DESCRIPTION
I found interface becomes unresponsive on linux for some time after series of resizes or moving one window above another. This is fix.