### PR TITLE
fix tooltips blinking

### DIFF
--- a/src/dlangui/platforms/common/platform.d
+++ b/src/dlangui/platforms/common/platform.d
@@ -875,11 +875,13 @@ class Window : CustomEventTarget {
         if (_mainWidget is null)
             return false;
 
+        bool actualChange = true;
         if (event.action == MouseAction.Move) {
+            actualChange = (_lastMouseX != event.x || _lastMouseY != event.y);
             _lastMouseX = event.x;
             _lastMouseY = event.y;
         }
-        hideTooltip();
+        if (actualChange) hideTooltip();
 
         PopupWidget modal = modalPopup();
 


### PR DESCRIPTION
On a desktop PC with Win 7 and a real mouse connected with PS/2 I observed that even if mouse was not touched, once a second several identical MouseMove messages were received by a DLangUI app (e.g. DLangIDE) and that caused tooltips to blink, since any mouse or keyboard message hides the tooltip, and MouseMove makes it appear again 200 ms later. 
See: http://stuff.thedeemon.com/blinking.html   (screen recording, 0.5 MB)