### PR TITLE
Minimal error reporting for SDL_Init

### DIFF
--- a/src/dlangui/platforms/sdl/sdlapp.d
+++ b/src/dlangui/platforms/sdl/sdlapp.d
@@ -1749,7 +1749,7 @@ int sdlmain(string[] args) {
 
     SDL_DisplayMode displayMode;
     if (SDL_Init(SDL_INIT_VIDEO|SDL_INIT_TIMER|SDL_INIT_EVENTS|SDL_INIT_NOPARACHUTE) != 0) {
-        Log.e("Cannot init SDL2");    
+        Log.e("Cannot init SDL2: ", SDL_GetError().to!string());
         return 2;
     }
     scope(exit)SDL_Quit();


### PR DESCRIPTION
I checked out DlangIDE today, which "failed to initialize SDL2", so I tried DlangUI's Tetris which printed the same error, with no clue what subsystem failed out of the three. Other SDL2 games run just fine.

With this patch it now prints: "Cannot init SDL2: SDL not built with thread support".

I assume the game(s) I have that use SDL2, replace the simplistic timer interface with something home grown. Whether or not DlangUI depends on it, I leave up to you. My configuration is certainly not common, but passing errors on to the user should be.