### PR TITLE
Remove warnings for x11 build

### DIFF
--- a/src/dlangui/platforms/x11/x11app.d
+++ b/src/dlangui/platforms/x11/x11app.d
@@ -14,6 +14,7 @@ import dlangui.widgets.styles;
 import dlangui.widgets.widget;
 import dlangui.platforms.common.platform;
 
+import core.stdc.string;
 import std.stdio;
 import std.string;
 import std.utf;
@@ -372,7 +373,7 @@ class X11Window : DWindow {
 	override void invalidate() {
 		Log.d("Window.invalidate()");
 		XEvent ev;
-		core.stdc.string.memset(&ev, 0, ev.sizeof);
+		memset(&ev, 0, ev.sizeof);
 		ev.type = Expose;
 		ev.xexpose.window = _win;
 
@@ -889,7 +890,7 @@ class X11Window : DWindow {
 	override protected void scheduleSystemTimer(long intervalMillis) {
 		if (!timer) {
 			timer = new TimerThread(delegate() {
-				core.stdc.string.memset(&ev, 0, ev.sizeof);
+				memset(&ev, 0, ev.sizeof);
 				//ev.xclient = XClientMessageEvent.init;
 				ev.xclient.type = ClientMessage;
 				ev.xclient.message_type = atom_DLANGUI_TIMER_EVENT;
@@ -928,7 +929,7 @@ class X11Window : DWindow {
 	override void postEvent(CustomEvent event) {
 		super.postEvent(event);
 		XEvent ev;
-		core.stdc.string.memset(&ev, 0, ev.sizeof);
+		memset(&ev, 0, ev.sizeof);
 		ev.xclient.type = ClientMessage;
 		ev.xclient.window = _win;
 		ev.xclient.display = x11display2;


### PR DESCRIPTION
This request removes the following warnings in x11 configuration.
I just added `import core.stdc.string;` to `x11app.d`.

```
$ dub build -c x11
Performing "debug" build using dmd for x86_64.
dlangui 0.7.31+commit.418.g195cebc: building configuration "x11"...
src/dlangui/platforms/x11/x11app.d(375,7): Deprecation: package core.stdc is not accessible here
src/dlangui/platforms/x11/x11app.d(375,12): Deprecation: module core.stdc.string is not accessible here, perhaps add 'static import core.stdc.string;'
src/dlangui/platforms/x11/x11app.d(892,9): Deprecation: package core.stdc is not accessible here
src/dlangui/platforms/x11/x11app.d(892,14): Deprecation: module core.stdc.string is not accessible here, perhaps add 'static import core.stdc.string;'
src/dlangui/platforms/x11/x11app.d(931,7): Deprecation: package core.stdc is not accessible here
src/dlangui/platforms/x11/x11app.d(931,12): Deprecation: module core.stdc.string is not accessible here, perhaps add 'static import core.stdc.string;'
```