### PR TITLE
Call correctCaretPos() after keyboard navigation

### DIFF
--- a/src/dlangui/widgets/editors.d
+++ b/src/dlangui/widgets/editors.d
@@ -2390,6 +2390,7 @@ class EditBox : EditWidgetBase {
             case SelectUp:
                 if (_caretPos.line > 0) {
                     _caretPos.line--;
+					correctCaretPos();
                     updateSelectionAfterCursorMovement(oldCaretPos, (a.id & 1) != 0);
                     ensureCaretVisible();
                 }
@@ -2398,6 +2399,7 @@ class EditBox : EditWidgetBase {
             case SelectDown:
                 if (_caretPos.line < _content.length - 1) {
                     _caretPos.line++;
+					correctCaretPos();
                     updateSelectionAfterCursorMovement(oldCaretPos, (a.id & 1) != 0);
                     ensureCaretVisible();
                 }
@@ -2407,6 +2409,7 @@ class EditBox : EditWidgetBase {
                 {
                     ensureCaretVisible();
                     _caretPos.line = _firstVisibleLine;
+					correctCaretPos();
                     updateSelectionAfterCursorMovement(oldCaretPos, (a.id & 1) != 0);
                 }
                 return true;
@@ -2419,6 +2422,7 @@ class EditBox : EditWidgetBase {
                     if (newpos >= _content.length)
                         newpos = _content.length - 1;
                     _caretPos.line = newpos;
+					correctCaretPos();
                     updateSelectionAfterCursorMovement(oldCaretPos, (a.id & 1) != 0);
                 }
                 return true;
@@ -2436,6 +2440,7 @@ class EditBox : EditWidgetBase {
                         _firstVisibleLine = newpos;
                         _caretPos.line -= delta;
                     }
+					correctCaretPos();
                     measureVisibleText();
                     updateScrollBars();
                     updateSelectionAfterCursorMovement(oldCaretPos, (a.id & 1) != 0);
@@ -2454,6 +2459,7 @@ class EditBox : EditWidgetBase {
                         _firstVisibleLine = newpos;
                         _caretPos.line += delta;
                     }
+					correctCaretPos();
                     measureVisibleText();
                     updateScrollBars();
                     updateSelectionAfterCursorMovement(oldCaretPos, (a.id & 1) != 0);

--- a/src/dlangui/widgets/editors.d
+++ b/src/dlangui/widgets/editors.d
@@ -2390,7 +2390,7 @@ class EditBox : EditWidgetBase {
             case SelectUp:
                 if (_caretPos.line > 0) {
                     _caretPos.line--;
-					correctCaretPos();
+                    correctCaretPos();
                     updateSelectionAfterCursorMovement(oldCaretPos, (a.id & 1) != 0);
                     ensureCaretVisible();
                 }
@@ -2399,7 +2399,7 @@ class EditBox : EditWidgetBase {
             case SelectDown:
                 if (_caretPos.line < _content.length - 1) {
                     _caretPos.line++;
-					correctCaretPos();
+                    correctCaretPos();
                     updateSelectionAfterCursorMovement(oldCaretPos, (a.id & 1) != 0);
                     ensureCaretVisible();
                 }
@@ -2409,7 +2409,7 @@ class EditBox : EditWidgetBase {
                 {
                     ensureCaretVisible();
                     _caretPos.line = _firstVisibleLine;
-					correctCaretPos();
+                    correctCaretPos();
                     updateSelectionAfterCursorMovement(oldCaretPos, (a.id & 1) != 0);
                 }
                 return true;
@@ -2422,7 +2422,7 @@ class EditBox : EditWidgetBase {
                     if (newpos >= _content.length)
                         newpos = _content.length - 1;
                     _caretPos.line = newpos;
-					correctCaretPos();
+                    correctCaretPos();
                     updateSelectionAfterCursorMovement(oldCaretPos, (a.id & 1) != 0);
                 }
                 return true;
@@ -2440,7 +2440,7 @@ class EditBox : EditWidgetBase {
                         _firstVisibleLine = newpos;
                         _caretPos.line -= delta;
                     }
-					correctCaretPos();
+                    correctCaretPos();
                     measureVisibleText();
                     updateScrollBars();
                     updateSelectionAfterCursorMovement(oldCaretPos, (a.id & 1) != 0);
@@ -2459,7 +2459,7 @@ class EditBox : EditWidgetBase {
                         _firstVisibleLine = newpos;
                         _caretPos.line += delta;
                     }
-					correctCaretPos();
+                    correctCaretPos();
                     measureVisibleText();
                     updateScrollBars();
                     updateSelectionAfterCursorMovement(oldCaretPos, (a.id & 1) != 0);


### PR DESCRIPTION
If the up/down arrow keys were used for keyboard navigation in a
multiline editbox, the position of the caret would become invalid
because it was not updated to fit in the new line. This caused
incorrect behaviour when entering text after such navigation
(ie replacing text when it should have appended).

To reproduce the bug, start the helloworld example, select the editbox, and type:
"f" enter "fd" enter up "j"
It will replace "f" character with "j".

This bug badly affects the usability of dlangide, so I would like to see this fix applied there soon.