### PR TITLE
Fix implicit string concatenations

### DIFF
--- a/3rdparty/android/android_native_app_glue_impl.d
+++ b/3rdparty/android/android_native_app_glue_impl.d
@@ -69,8 +69,8 @@ static void print_cur_config(android_app* android_app) {
     AConfiguration_getLanguage(android_app.config, lang.ptr);
     AConfiguration_getCountry(android_app.config, country.ptr);
 
-    LOGV("Config: mcc=%d mnc=%d lang=%c%c cnt=%c%c orien=%d touch=%d dens=%d "
-            "keys=%d nav=%d keysHid=%d navHid=%d sdk=%d size=%d long=%d "
+    LOGV("Config: mcc=%d mnc=%d lang=%c%c cnt=%c%c orien=%d touch=%d dens=%d " ~
+            "keys=%d nav=%d keysHid=%d navHid=%d sdk=%d size=%d long=%d " ~
             "modetype=%d modenight=%d",
             AConfiguration_getMcc(android_app.config),
             AConfiguration_getMnc(android_app.config),

--- a/src/dlangui/core/css.d
+++ b/src/dlangui/core/css.d
@@ -630,9 +630,9 @@ unittest {
     CssTextAlign textAlignLast = CssTextAlign.inherit;
     CssTextDecoration textDecoration = CssTextDecoration.inherit;
     CssHyphenate hyphenate = CssHyphenate.inherit;
-    string src = "{ display: inline; text-decoration: underline; white-space: pre; text-align: right; text-align-last: left; "
-        "hyphenate: auto; width: 70%; height: 1.5pt; margin-left: 2.0em; "
-        "font-family: Arial, 'Times New Roman', sans-serif; font-size: 18pt; line-height: 120%; letter-spacing: 2px; font-weight: 300; "
+    string src = "{ display: inline; text-decoration: underline; white-space: pre; text-align: right; text-align-last: left; " ~
+        "hyphenate: auto; width: 70%; height: 1.5pt; margin-left: 2.0em; " ~
+        "font-family: Arial, 'Times New Roman', sans-serif; font-size: 18pt; line-height: 120%; letter-spacing: 2px; font-weight: 300; " ~
         " }tail";
     CssDeclaration decl = parseCssDeclaration(src, true);
     assert(decl !is null);


### PR DESCRIPTION
This request fixes implicit string concatenations, which are deprecated from 2.072 ([Details in dlang.org](https://dlang.org/deprecate.html#Implicit%20string%20concatenation)).
