### PR TITLE
Improved the file dialog path selection again

### DIFF
--- a/src/dlangui/dialogs/filedlg.d
+++ b/src/dlangui/dialogs/filedlg.d
@@ -456,8 +456,14 @@ class FileDialog : Dialog, CustomGridCellAdapter {
             return true;
         }
         if (action.id == StandardAction.Open || action.id == StandardAction.OpenDirectory || action.id == StandardAction.Save) {
-            _filename = _path ~ dirSeparator ~ toUTF8(_edFilename.text);
-            if (_filename.length > 0) {
+            auto baseFilename = toUTF8(_edFilename.text);
+            _filename = _path ~ dirSeparator ~ baseFilename;
+            
+            if (action.id != StandardAction.OpenDirectory && isDir(_filename)) {
+                auto row = _fileList.row();
+                onItemActivated(row);
+                return true;
+            } else if (baseFilename.length > 0) {
                 Action result = _action;
                 result.stringParam = _filename;
                 // success if either selected dir & has to open dir or if selected file
@@ -467,10 +473,6 @@ class FileDialog : Dialog, CustomGridCellAdapter {
                     close(result);
                     return true;
                 }
-            } else if (_filename.length == 0){
-                 auto row = _fileList.row();
-                 onItemActivated(row);
-                 return true;
             }
         }
         return super.handleAction(action);

--- a/src/dlangui/dialogs/filedlg.d
+++ b/src/dlangui/dialogs/filedlg.d
@@ -456,6 +456,7 @@ class FileDialog : Dialog, CustomGridCellAdapter {
             return true;
         }
         if (action.id == StandardAction.Open || action.id == StandardAction.OpenDirectory || action.id == StandardAction.Save) {
+            _filename = _path ~ dirSeparator ~ toUTF8(_edFilename.text);
             if (_filename.length > 0) {
                 Action result = _action;
                 result.stringParam = _filename;
@@ -542,10 +543,6 @@ class FileDialog : Dialog, CustomGridCellAdapter {
         if (_flags & FileDialogFlag.SelectDirectory) {
             _edFilename.visibility = Visibility.Gone;
         }
-        if ((_flags & FileDialogFlag.Save) && !(_flags & FileDialogFlag.FileMustExist)) {
-            _edFilename.contentChange = &onFilenameTyped;
-        }
-
 
         //_edFilename.layoutWeight = 0;
         fnlayout.addChild(_edFilename);
@@ -639,10 +636,6 @@ class FileDialog : Dialog, CustomGridCellAdapter {
     override void onShow() {
         _fileList.setFocus();
     }
-
-    void onFilenameTyped(EditableContent content) {
-        _filename = _path ~ dirSeparator ~ toUTF8(content.text);
-    } 
 }
 
 interface OnPathSelectionHandler {
@@ -1007,3 +1000,4 @@ class DirEditLine : FileNameEditLine {
 }
 
 //import dlangui.widgets.metadata;
+//mixin(registerWidgets!(FileNameEditLine, DirEditLine)());


### PR DESCRIPTION
I realized my solution from before was probably not suitable - allocating a new string every time the user typed in a character in the filename box was certainly not a good idea. This is a much cleaner solution. Would you say that what I have here is your preferred "user experience"? Thanks!