### PR TITLE
Fix selection combobox list when changing selected item from code.

### DIFF
--- a/src/dlangui/widgets/combobox.d
+++ b/src/dlangui/widgets/combobox.d
@@ -68,6 +68,9 @@ class ComboBoxBase : HorizontalLayout, OnClickHandler {
     @property ComboBoxBase selectedItemIndex(int index) {
         if (_selectedItemIndex == index)
             return this;
+        if (_selectedItemIndex != -1) {
+            _adapter.resetItemState(_selectedItemIndex, State.Selected | State.Focused | State.Hovered);
+        }
         _selectedItemIndex = index;
         if (itemClick.assigned)
             itemClick(this, index);


### PR DESCRIPTION
When we change selection in combo from code list adapter is not updated. This little patch fix it.

For example when we have app with combo and button which select "Element 1": 

    import dlangui;

    mixin APP_ENTRY_POINT;


    extern (C) int UIAppMain(string[] args) {
    
    
        Window window = Platform.instance.createWindow("Window", null, WindowFlag.Resizable, 200, 300);
    
        VerticalLayout vl = new VerticalLayout();
    
        ComboBox cb = new ComboBox(null, ["Element 0"d, "Element 1"d, "Element 2"d]);
    
        vl.addChild(cb);
    
        Button select1Button = new Button(null,"Select 1"d);
        vl.addChild(select1Button);
        select1Button.click = delegate bool(Widget src) {
            cb.selectedItemIndex = 1;
            return true;
        };
    
        window.mainWidget = vl;
    
        window.show();
    
        return Platform.instance.enterMessageLoop();
    }

When you run this app and change element to "Element 0" and next click button there will be two items selected:
![combobox_before](https://cloud.githubusercontent.com/assets/18555708/24161497/dc78eea6-0e64-11e7-8c61-159c8db7ff03.png)

With this patch will work fine (one item selected):
![combobox_after](https://cloud.githubusercontent.com/assets/18555708/24161538/fd46cc16-0e64-11e7-9b44-d58087547928.png)


