### PR TITLE
Fix scrollbox sliders update issues (fix #192)

### DIFF
--- a/src/dlangui/widgets/scrollbar.d
+++ b/src/dlangui/widgets/scrollbar.d
@@ -84,7 +84,7 @@ class AbstractSlider : WidgetGroup {
     @property AbstractSlider pageSize(int size) {
         if (_pageSize != size) {
             _pageSize = size;
-            //requestLayout();
+            requestLayout();
         }
         return this;
     }
@@ -107,7 +107,7 @@ class AbstractSlider : WidgetGroup {
         if (_minValue != min || _maxValue != max) {
             _minValue = min;
             _maxValue = max;
-            //requestLayout();
+            requestLayout();
         }
         return this;
     }


### PR DESCRIPTION
After investigation I uncommented two requestLayout():

- reqestLayout() in pageSize() is required to properly update scrollbox sliders when scrollbox is resized.
- reqestLayout() in setRange() is required to properly update scrollbox sliders when you add widgets to contentWidget