### PR TITLE
Fix MultilineTextWidget measure. Possible fix #100.

### DIFF
--- a/src/dlangui/widgets/controls.d
+++ b/src/dlangui/widgets/controls.d
@@ -122,7 +122,7 @@ class TextWidget : Widget {
         if (maxLines == 1) {
             sz = font.textSize(text, MAX_WIDTH_UNSPECIFIED, 4, 0, textFlags);
         } else {
-            sz = font.measureMultilineText(text, maxLines, MAX_WIDTH_UNSPECIFIED, 4, 0, textFlags);
+            sz = font.measureMultilineText(text,maxLines,parentWidth-margins.left-margins.right-padding.left-padding.right, 4, 0, textFlags);
         }
         //auto measureEnd = std.datetime.Clock.currAppTick;
         //auto duration = measureEnd - measureStart;


### PR DESCRIPTION
Measuring of MultilineTextWidget always return one line height but try draw multiline. 

For example:

    extern (C) int UIAppMain(string[] args) {
    
    
        Window window = Platform.instance.createWindow("Window", null, WindowFlag.Resizable, 200, 300);
    
        VerticalLayout vl = new VerticalLayout();
    
        MultilineTextWidget mtxt = new MultilineTextWidget(null, "very long text aqwertyuiop asdfghjkl zxcvbnm aqwertyuiop asdfghjkl zxcvbnm aqwertyuiop asdfghjkl zxcvbnm"d);
    
        vl.addChild(mtxt);
        window.mainWidget = vl;
    
        window.show();
    
        return Platform.instance.enterMessageLoop();
    }

Looks like:
![multilinetextwidget_before](https://cloud.githubusercontent.com/assets/18555708/24214960/7711412a-0f37-11e7-9465-1634aee91ae8.png)

With this patch:
![multilinetextwidget_after](https://cloud.githubusercontent.com/assets/18555708/24215005/a29ae102-0f37-11e7-9621-67362b855c1d.png)

Possibly fix #100 
