### PR TITLE
Queue widget destroy support

### DIFF
--- a/src/dlangui/core/events.d
+++ b/src/dlangui/core/events.d
@@ -1649,6 +1649,20 @@ class RunnableEvent : CustomEvent {
     }
 }
 
+/// save destroy event
+class SafeDestroyEvent : RunnableEvent {
+    Widget _widgetToDestroy;
+    this (Widget widgetToDestroy)
+    {
+        _widgetToDestroy = widgetToDestroy;
+        super(1,null, delegate void () {
+            if (_widgetToDestroy.parent) 
+                _widgetToDestroy.parent.removeChild(_widgetToDestroy);
+            destroy(_widgetToDestroy);
+        });
+    }
+}
+
 interface CustomEventTarget {
     /// post event to handle in UI thread (this method can be used from background thread)
     void postEvent(CustomEvent event);

--- a/src/dlangui/core/events.d
+++ b/src/dlangui/core/events.d
@@ -1649,8 +1649,8 @@ class RunnableEvent : CustomEvent {
     }
 }
 
-/// save destroy event
-class SafeDestroyEvent : RunnableEvent {
+/// queue destroy event
+class QueueDestroyEvent : RunnableEvent {
     Widget _widgetToDestroy;
     this (Widget widgetToDestroy)
     {

--- a/src/dlangui/core/events.d
+++ b/src/dlangui/core/events.d
@@ -1649,9 +1649,14 @@ class RunnableEvent : CustomEvent {
     }
 }
 
-/// queue destroy event
+/**
+Queue destroy event.
+
+This event allows delayed widget destruction and is used internally by 
+$(LINK2 $(DDOX_ROOT_DIR)dlangui/platforms/common/platform/Window.queueWidgetDestroy.html, Window.queueWidgetDestroy()).
+*/
 class QueueDestroyEvent : RunnableEvent {
-    Widget _widgetToDestroy;
+    private Widget _widgetToDestroy;
     this (Widget widgetToDestroy)
     {
         _widgetToDestroy = widgetToDestroy;

--- a/src/dlangui/platforms/common/platform.d
+++ b/src/dlangui/platforms/common/platform.d
@@ -519,7 +519,18 @@ class Window : CustomEventTarget {
         destroy(_timerQueue);
         _eventList = null;
     }
-    /// queue destroy widget
+    
+    /**
+    Allows queue destroy of widget.
+    
+    Sometimes when you have very complicated UI with dynamic create/destroy lists of widgets calling simple destroy() 
+    on widget makes segmentation fault.
+    
+    Usually because you destroy widget that on some stage call another that tries to destroy widget that calls it.
+    When the control flow returns widget not exist and you have seg. fault.
+    
+    This function use internally $(LINK2 $(DDOX_ROOT_DIR)dlangui/core/events/QueueDestroyEvent.html, QueueDestroyEvent).
+    */
     void queueWidgetDestroy(Widget widgetToDestroy)
     {
         QueueDestroyEvent ev = new QueueDestroyEvent(widgetToDestroy);

--- a/src/dlangui/platforms/common/platform.d
+++ b/src/dlangui/platforms/common/platform.d
@@ -519,10 +519,10 @@ class Window : CustomEventTarget {
         destroy(_timerQueue);
         _eventList = null;
     }
-    /// safe destroy widget
-    void safeWidgetDestroy(Widget widgetToDestroy)
+    /// queue destroy widget
+    void queueWidgetDestroy(Widget widgetToDestroy)
     {
-        SafeDestroyEvent ev = new SafeDestroyEvent(widgetToDestroy);
+        QueueDestroyEvent ev = new QueueDestroyEvent(widgetToDestroy);
         postEvent(ev);
     }
     

--- a/src/dlangui/platforms/common/platform.d
+++ b/src/dlangui/platforms/common/platform.d
@@ -519,7 +519,13 @@ class Window : CustomEventTarget {
         destroy(_timerQueue);
         _eventList = null;
     }
-
+    /// safe destroy widget
+    void safeWidgetDestroy(Widget widgetToDestroy)
+    {
+        SafeDestroyEvent ev = new SafeDestroyEvent(widgetToDestroy);
+        postEvent(ev);
+    }
+    
     private void animate(Widget root, long interval) {
         if (root is null)
             return;


### PR DESCRIPTION
Sometimes when you have very complicated UI with dynamic create/destroy lists of widgets calling simple destroy() on widget makes segmentation fault. 

Usually because you destroy widget that on some stage call another that tries to destroy widget that calls it. When the control flow returns widget not exist and you have seg. fault. Most GUI library have some method to make delay destroy. This PR add ability to queued delete by calling window method queueDestroyWidget().
