### PR TITLE
Added multi selection to string grid and filedlg, issue #23

### DIFF
--- a/examples/example1/src/example1.d
+++ b/examples/example1/src/example1.d
@@ -384,6 +384,7 @@ extern (C) int UIAppMain(string[] args) {
                 UIString caption;
                 caption = "Open Text File"d;
                 FileDialog dlg = new FileDialog(caption, window, null);
+                dlg.allowMultipleFiles = true;
                 dlg.addFilter(FileFilterEntry(UIString("FILTER_ALL_FILES", "All files (*)"d), "*"));
                 dlg.addFilter(FileFilterEntry(UIString("FILTER_TEXT_FILES", "Text files (*.txt)"d), "*.txt"));
                 dlg.addFilter(FileFilterEntry(UIString("FILTER_SOURCE_FILES", "Source files"d), "*.d;*.dd;*.c;*.cc;*.cpp;*.h;*.hpp"));
@@ -391,29 +392,31 @@ extern (C) int UIAppMain(string[] args) {
                 //dlg.filterIndex = 2;
                 dlg.dialogResult = delegate(Dialog dlg, const Action result) {
                     if (result.id == ACTION_OPEN.id) {
-                        string filename = result.stringParam;
-                        if (filename.endsWith(".d") || filename.endsWith(".txt") || filename.endsWith(".cpp") || filename.endsWith(".h") || filename.endsWith(".c")
-                            || filename.endsWith(".json") || filename.endsWith(".dd") || filename.endsWith(".ddoc") || filename.endsWith(".xml") || filename.endsWith(".html")
-                            || filename.endsWith(".html") || filename.endsWith(".css") || filename.endsWith(".log") || filename.endsWith(".hpp")) {
-                                // open source file in tab
-                                int index = tabs.tabIndex(filename);
-                                if (index >= 0) {
-                                    // file is already opened in tab
-                                    tabs.selectTab(index, true);
-                                } else {
-                                    SourceEdit editor = new SourceEdit(filename);
-                                    if (editor.load(filename)) {
-                                        tabs.addTab(editor, toUTF32(baseName(filename)), null, true);
-                                        tabs.selectTab(filename);
+                        string[] filenames = (cast(FileDialog)dlg).filenames;
+                        foreach (filename; filenames) {
+                            if (filename.endsWith(".d") || filename.endsWith(".txt") || filename.endsWith(".cpp") || filename.endsWith(".h") || filename.endsWith(".c")
+                                || filename.endsWith(".json") || filename.endsWith(".dd") || filename.endsWith(".ddoc") || filename.endsWith(".xml") || filename.endsWith(".html")
+                                || filename.endsWith(".html") || filename.endsWith(".css") || filename.endsWith(".log") || filename.endsWith(".hpp")) {
+                                    // open source file in tab
+                                    int index = tabs.tabIndex(filename);
+                                    if (index >= 0) {
+                                        // file is already opened in tab
+                                        tabs.selectTab(index, true);
                                     } else {
-                                        destroy(editor);
-                                        window.showMessageBox(UIString("File open error"d), UIString("Cannot open file "d ~ toUTF32(filename)));
+                                        SourceEdit editor = new SourceEdit(filename);
+                                        if (editor.load(filename)) {
+                                            tabs.addTab(editor, toUTF32(baseName(filename)), null, true);
+                                            tabs.selectTab(filename);
+                                        } else {
+                                            destroy(editor);
+                                            window.showMessageBox(UIString("File open error"d), UIString("Cannot open file "d ~ toUTF32(filename)));
+                                        }
                                     }
+                                } else {
+                                    Log.d("FileDialog.onDialogResult: ", result, " param=", result.stringParam);
+                                    window.showMessageBox(UIString("FileOpen result"d), UIString("Filename: "d ~ toUTF32(filename)));
                                 }
-                            } else {
-                                Log.d("FileDialog.onDialogResult: ", result, " param=", result.stringParam);
-                                window.showMessageBox(UIString("FileOpen result"d), UIString("Filename: "d ~ toUTF32(filename)));
-                            }
+                        }
                     }
 
                 };
@@ -950,6 +953,7 @@ void main()
         grid.fixedCols = 3;
         grid.fixedRows = 2;
         //grid.rowSelect = true; // testing full row selection
+        grid.multiSelect = true;
         grid.selectCell(4, 6, false);
         // create sample grid content
         for (int y = 0; y < grid.rows; y++) {

--- a/src/dlangui/core/types.d
+++ b/src/dlangui/core/types.d
@@ -56,6 +56,10 @@ struct Point {
     Point opBinary(string op)(Point v) if (op == "-") {
         return Point(x - v.x, y - v.y);
     }
+    int opCmp(ref const Point b) const {
+        if (x == b.x) return y - b.y;
+        return x - b.x;
+    }
 }
 
 /// 2D rectangle

--- a/src/dlangui/dialogs/filedlg.d
+++ b/src/dlangui/dialogs/filedlg.d
@@ -120,6 +120,7 @@ class FileDialog : Dialog, CustomGridCellAdapter {
     protected bool _isOpenDialog;
 
     protected bool _showHiddenFiles;
+    protected bool _allowMultipleFiles;
 
     protected string[string] _filetypeIcons;
 
@@ -183,6 +184,18 @@ class FileDialog : Dialog, CustomGridCellAdapter {
         _filename = s;
     }
 
+    /// all the selected filenames
+    @property string[] filenames() {
+        string[] res;
+        res.reserve(_fileList.selection.length);
+        int i = 0;
+        foreach (val; _fileList.selection) {
+            res ~= _entries[val.y];
+            ++i;
+        }
+        return res;
+    }
+
     @property bool showHiddenFiles() {
         return _showHiddenFiles;
     }
@@ -191,6 +204,14 @@ class FileDialog : Dialog, CustomGridCellAdapter {
         _showHiddenFiles = b;
     }
 
+    @property bool allowMultipleFiles() {
+        return _allowMultipleFiles;
+    }
+
+    @property void allowMultipleFiles(bool b) {
+        _allowMultipleFiles = b;
+    }
+    
     /// return currently selected filter value - array of patterns like ["*.txt", "*.rtf"]
     @property string[] selectedFilter() {
         if (_filterIndex >= 0 && _filterIndex < _filters.length)
@@ -575,6 +596,7 @@ class FileDialog : Dialog, CustomGridCellAdapter {
         _fileList.setColTitle(3, "Modified"d);
         _fileList.showRowHeaders = false;
         _fileList.rowSelect = true;
+        _fileList.multiSelect = _allowMultipleFiles;
         _fileList.cellPopupMenu = &getCellPopupMenu;
         _fileList.menuItemAction = &handleAction;
 


### PR DESCRIPTION
Please review carefully as this is my first serious work with DLang though I consider myself experienced developer otherwise :).

I added multiSelect support to GridWidgetBase and I covered selecting with Shift+Mouse, Ctrl+Mouse and Shift + (Up, Down, Left, Right, PgUp, PgDown, Home, End) and some of those with Ctrl as well. I think those are all combinations. I also changed that in case rowSelect is true and user presses Home or End it actually goes to first/last row and same for selecting. Then I added allowMultipleFiles property to FileDialog and a new filenames property that returns a string[] of all selected entries. In case allowMultipleFiles is false this new property still returns an array of one element after open action.