### PR TITLE
SDL modal behavior and setting window state.

### DIFF
--- a/src/dlangui/platforms/sdl/sdlapp.d
+++ b/src/dlangui/platforms/sdl/sdlapp.d
@@ -103,7 +103,7 @@ class SDLWindow : Window {
         debug Log.d("Destroying SDL window");
         
         if (_parent) {
-            long index = countUntil(_parent._children,this);
+            ptrdiff_t index = countUntil(_parent._children,this);
             if (index > -1 ) {
                 _parent._children=_parent._children.remove(index);
             }


### PR DESCRIPTION
This PR add support for WindowFlag.Modal based on blocking events when there are child window with Modal flag. Modal windows are always raising on top of parent windows. Minimizing modal window minimizing all forms. Minimizing parent windows minimize modal children. Restoration of parent window restore modal window. 
Tested on Linux Mint (Cinamon, XFCE), Windows XP, Windows 7.