### PR TITLE
Fix window close in SDL

### DIFF
--- a/src/dlangui/platforms/sdl/sdlapp.d
+++ b/src/dlangui/platforms/sdl/sdlapp.d
@@ -1235,7 +1235,6 @@ class SDLPlatform : Platform {
                                 if (windowToClose.windowId in _windowMap) {
                                     Log.i("Platform.closeWindow()");
                                     _windowMap.remove(windowToClose.windowId);
-                                    SDL_DestroyWindow(windowToClose._win);
                                     Log.i("windowMap.length=", _windowMap.length);
                                     destroy(windowToClose);
                                 }

--- a/src/dlangui/platforms/sdl/sdlapp.d
+++ b/src/dlangui/platforms/sdl/sdlapp.d
@@ -74,6 +74,7 @@ private derelict.util.exception.ShouldThrow missingSymFunc( string symName ) {
 
 private __gshared uint USER_EVENT_ID;
 private __gshared uint TIMER_EVENT_ID;
+private __gshared uint WINDOW_CLOSE_EVENT_ID;
 
 class SDLWindow : Window {
     SDLPlatform _platform;
@@ -1001,12 +1002,14 @@ class SDLPlatform : Platform {
         return null;
     }
 
-    SDLWindow _windowToClose;
-
     /// close window
     override void closeWindow(Window w) {
         SDLWindow window = cast(SDLWindow)w;
-        _windowToClose = window;
+        SDL_Event sdlevent;
+        sdlevent.user.type = WINDOW_CLOSE_EVENT_ID;
+        sdlevent.user.code = 0;
+        sdlevent.user.windowID = window.windowId;
+        SDL_PushEvent(&sdlevent);
     }
 
     /// calls request layout for all windows
@@ -1225,19 +1228,20 @@ class SDLPlatform : Platform {
                             SDLWindow w = getWindow(event.user.windowID);
                             if (w) {
                                 w.handleTimer(cast(uint)event.user.code);
+                            } 
+                        } else if (event.type == WINDOW_CLOSE_EVENT_ID) {
+                            SDLWindow windowToClose = getWindow(event.user.windowID);
+                            if(windowToClose) {
+                                if (windowToClose.windowId in _windowMap) {
+                                    Log.i("Platform.closeWindow()");
+                                    _windowMap.remove(windowToClose.windowId);
+                                    SDL_DestroyWindow(windowToClose._win);
+                                    Log.i("windowMap.length=", _windowMap.length);
+                                    destroy(windowToClose);
+                                }
                             }
                         }
                         break;
-                }
-                if (_windowToClose) {
-                    if (_windowToClose.windowId in _windowMap) {
-                        Log.i("Platform.closeWindow()");
-                        _windowMap.remove(_windowToClose.windowId);
-                        SDL_DestroyWindow(_windowToClose._win);
-                        Log.i("windowMap.length=", _windowMap.length);
-                        destroy(_windowToClose);
-                    }
-                    _windowToClose = null;
                 }
                 if (_windowMap.length == 0) {
                     SDL_Quit();
@@ -1833,6 +1837,7 @@ int sdlmain(string[] args) {
 
     USER_EVENT_ID = SDL_RegisterEvents(1);
     TIMER_EVENT_ID = SDL_RegisterEvents(1);
+    WINDOW_CLOSE_EVENT_ID = SDL_RegisterEvents(1);
 
     int request = SDL_GetDesktopDisplayMode(0, &displayMode);
 


### PR DESCRIPTION
When you want close more than one window:

`window1.close();`
`window2.close();`


Only last is closed because _windowToClose can hold only one window. Changed to event. 

SDL_DestroyWindow() was called twice first in close() code second in window destructor (what makes sometime another window black or unexpected behavior).