### PR TITLE
SDL improvements

### DIFF
--- a/src/dlangui/platforms/sdl/sdlapp.d
+++ b/src/dlangui/platforms/sdl/sdlapp.d
@@ -87,7 +87,8 @@ class SDLWindow : Window {
     this(SDLPlatform platform, dstring caption, Window parent, uint flags, uint width = 0, uint height = 0) {
         _platform = platform;
         _caption = caption;
-        
+        _windowState = WindowState.hidden;
+       
         _parent = cast(SDLWindow) parent;
         if (_parent)
             _parent._children~=this;

--- a/src/dlangui/platforms/sdl/sdlapp.d
+++ b/src/dlangui/platforms/sdl/sdlapp.d
@@ -362,6 +362,10 @@ class SDLWindow : Window {
         _platform.closeWindow(this);
     }
     
+    override protected void handleWindowStateChange(WindowState newState, Rect newWindowRect = RECT_VALUE_IS_NOT_SET) {
+        super.handleWindowStateChange(newState, newWindowRect);
+    }
+    
     override bool setWindowState(WindowState newState, bool activate = false, Rect newWindowRect = RECT_VALUE_IS_NOT_SET) {
         // override for particular platforms
         

--- a/src/dlangui/platforms/sdl/sdlapp.d
+++ b/src/dlangui/platforms/sdl/sdlapp.d
@@ -371,59 +371,46 @@ class SDLWindow : Window {
             return false;
         
         bool res = false;
-        bool stateChanged = false;
         
         // change state
         switch(newState) {
             case WindowState.maximized:
-                if (_windowState != WindowState.maximized) {
+                if (_windowState != WindowState.maximized)
                     SDL_MaximizeWindow(_win);
-                    stateChanged = true;
-                }
                 res = true;
                 break;
             case WindowState.minimized:
-                if (_windowState != WindowState.minimized) {
+                if (_windowState != WindowState.minimized) 
                     SDL_MinimizeWindow(_win);
-                    stateChanged = true;
-                }
                 res = true;
                 break;
             case WindowState.hidden:
-                if (_windowState != WindowState.hidden) {
+                if (_windowState != WindowState.hidden)
                     SDL_HideWindow(_win);
-                    stateChanged = true;
-                }
                 res = true;
                 break;
             case WindowState.normal:
-                if (_windowState != WindowState.normal) {
+                if (_windowState != WindowState.normal) 
                     SDL_RestoreWindow(_win);
-                    stateChanged = true;
-                }
                 res = true;
                 break;
             default:
                 break;
         }
+        
         // change size and/or position
-        
-        bool windowRectChanged = false;
-        
         if (newWindowRect != RECT_VALUE_IS_NOT_SET && (newState == WindowState.normal || newState == WindowState.unspecified)) {
             
             // change position
             if (newWindowRect.top != int.min && newWindowRect.left != int.min) {
                 SDL_SetWindowPosition(_win, newWindowRect.left, newWindowRect.top);
                 res = true;
-                windowRectChanged = true;
             }
                 
             // change size
             if (newWindowRect.bottom != int.min && newWindowRect.right != int.min) {
                 SDL_SetWindowSize(_win, newWindowRect.right, newWindowRect.bottom);
                 res = true;
-                windowRectChanged = true;
             }
         }
         
@@ -431,8 +418,6 @@ class SDLWindow : Window {
             SDL_RaiseWindow(_win);
             res = true;
         }
-        
-        handleWindowStateChange(stateChanged ? newState : WindowState.unspecified, windowRectChanged ? newWindowRect : RECT_VALUE_IS_NOT_SET);
         
         return res;
     }
@@ -1239,6 +1224,7 @@ class SDLPlatform : Platform {
                             case SDL_WINDOWEVENT_SIZE_CHANGED:
                                 debug(DebugSDL) Log.d("SDL_WINDOWEVENT_SIZE_CHANGED win=", event.window.windowID, " pos=", event.window.data1,
                                         ",", event.window.data2);
+                                w.handleWindowStateChange(WindowState.unspecified, Rect(int.min, int.min, event.window.data1, event.window.data2));
                                 w.redraw();
                                 break;
                             case SDL_WINDOWEVENT_CLOSE:
@@ -1254,11 +1240,13 @@ class SDLPlatform : Platform {
                                 break;
                             case SDL_WINDOWEVENT_SHOWN:
                                 debug(DebugSDL) Log.d("SDL_WINDOWEVENT_SHOWN - ", w.windowCaption);
+                                w.handleWindowStateChange(WindowState.normal);
                                 if (!_windowsMinimized && w.hasModalChild())
                                     w.restoreModalChilds();
                                 break;
                             case SDL_WINDOWEVENT_HIDDEN:
                                 debug(DebugSDL) Log.d("SDL_WINDOWEVENT_HIDDEN - ", w.windowCaption);
+                                w.handleWindowStateChange(WindowState.hidden);
                                 break;
                             case SDL_WINDOWEVENT_EXPOSED:
                                 debug(DebugSDL) Log.d("SDL_WINDOWEVENT_EXPOSED - ", w.windowCaption);
@@ -1267,7 +1255,8 @@ class SDLPlatform : Platform {
                                 w.invalidate();
                                 break;
                             case SDL_WINDOWEVENT_MOVED:
-                                debug(DebugSDL) Log.d("SDL_WINDOWEVENT_MOVED- ", w.windowCaption);
+                                debug(DebugSDL) Log.d("SDL_WINDOWEVENT_MOVED - ", w.windowCaption);
+                                w.handleWindowStateChange(WindowState.unspecified, Rect(event.window.data1, event.window.data2, int.min, int.min));
                                 if (!_windowsMinimized && w.hasModalChild())
                                     w.restoreModalChilds();
                                 break;

--- a/src/dlangui/platforms/sdl/sdlapp.d
+++ b/src/dlangui/platforms/sdl/sdlapp.d
@@ -1238,13 +1238,15 @@ class SDLPlatform : Platform {
                                 break;
                             case SDL_WINDOWEVENT_SHOWN:
                                 debug(DebugSDL) Log.d("SDL_WINDOWEVENT_SHOWN - ", w.windowCaption);
-                                w.handleWindowStateChange(WindowState.normal);
+                                if (w.windowState()!=WindowState.normal)
+                                    w.handleWindowStateChange(WindowState.normal);
                                 if (!_windowsMinimized && w.hasVisibleModalChild())
                                     w.restoreModalChilds();
                                 break;
                             case SDL_WINDOWEVENT_HIDDEN:
                                 debug(DebugSDL) Log.d("SDL_WINDOWEVENT_HIDDEN - ", w.windowCaption);
-                                w.handleWindowStateChange(WindowState.hidden);
+                                if (w.windowState()!=WindowState.hidden)
+                                    w.handleWindowStateChange(WindowState.hidden);
                                 break;
                             case SDL_WINDOWEVENT_EXPOSED:
                                 debug(DebugSDL) Log.d("SDL_WINDOWEVENT_EXPOSED - ", w.windowCaption);
@@ -1260,18 +1262,18 @@ class SDLPlatform : Platform {
                                 break;
                             case SDL_WINDOWEVENT_MINIMIZED:
                                 debug(DebugSDL) Log.d("SDL_WINDOWEVENT_MINIMIZED - ", w.windowCaption);
-                                w.handleWindowStateChange(WindowState.minimized);
-                                
+                                if (w.windowState()!=WindowState.minimized)
+                                    w.handleWindowStateChange(WindowState.minimized);
                                 if (!_windowsMinimized && w.hasVisibleModalChild()) 
                                     w.minimizeModalChilds();
                                 if (!_windowsMinimized && w.flags & WindowFlag.Modal)
                                     w.minimizeParentWindows();
-                                    
                                 _windowsMinimized = true;
                                 break;
                             case SDL_WINDOWEVENT_MAXIMIZED:
                                 debug(DebugSDL) Log.d("SDL_WINDOWEVENT_MAXIMIZED - ", w.windowCaption);
-                                w.handleWindowStateChange(WindowState.maximized);
+                                if (w.windowState()!=WindowState.maximized)    
+                                    w.handleWindowStateChange(WindowState.maximized);
                                 _windowsMinimized = false;
                                 break;
                             case SDL_WINDOWEVENT_RESTORED:
@@ -1281,7 +1283,10 @@ class SDLPlatform : Platform {
                                     w.restoreParentWindows();
                                     w.restoreWindow(true);
                                 }
-                                w.handleWindowStateChange(WindowState.normal);
+
+                                if (w.windowState()!=WindowState.normal)
+                                    w.handleWindowStateChange(WindowState.normal);
+                                    
                                 if (w.hasVisibleModalChild())
                                     w.restoreModalChilds();
                                 version(linux) { //not sure if needed on Windows or OSX. Also need to check on FreeBSD


### PR DESCRIPTION
SDL improvements:
- window state was not set on create, so hidden window had normal window state - now set to hidden
- window state was unnecessarily set in setWindowState() - should only set after events
- resize/move window call handleWindowStateChange()
- fixed window freeze after create modal child but not show it.
- fixed deprecation warnings about using handleWindowStateChange() in SDL platform class.