### PR TITLE
Add dialog display mode to easy configure dialogs should be displayed as popup or window

### DIFF
--- a/src/dlangui/dialogs/filedlg.d
+++ b/src/dlangui/dialogs/filedlg.d
@@ -85,19 +85,6 @@ struct FileFilterEntry {
     }
 }
 
-static if (BACKEND_CONSOLE) {
-    __gshared bool SHOW_FILE_DIALOG_IN_POPUP = true;
-} else {
-    version (Windows) {
-        static if (BACKEND_SDL) {
-            __gshared bool SHOW_FILE_DIALOG_IN_POPUP = false;
-        } else {
-            __gshared bool SHOW_FILE_DIALOG_IN_POPUP = false;
-        }
-    } else {
-        __gshared bool SHOW_FILE_DIALOG_IN_POPUP = false;
-    }
-}
 
 /// File open / save dialog
 class FileDialog : Dialog, CustomGridCellAdapter {
@@ -125,7 +112,7 @@ class FileDialog : Dialog, CustomGridCellAdapter {
     protected string[string] _filetypeIcons;
 
     this(UIString caption, Window parent, Action action = null, uint fileDialogFlags = DialogFlag.Modal | DialogFlag.Resizable | FileDialogFlag.FileMustExist) {
-        super(caption, parent, fileDialogFlags | (SHOW_FILE_DIALOG_IN_POPUP ? DialogFlag.Popup : 0));
+        super(caption, parent, fileDialogFlags | (Platform.instance.uiDialogDisplayMode & DialogDisplayMode.fileDialogInPopup ? DialogFlag.Popup : 0));
         _isOpenDialog = !(_flags & FileDialogFlag.ConfirmOverwrite);
         if (action is null) {
             if (fileDialogFlags & FileDialogFlag.SelectDirectory)

--- a/src/dlangui/dialogs/inputbox.d
+++ b/src/dlangui/dialogs/inputbox.d
@@ -16,7 +16,7 @@ class InputBox : Dialog {
     protected int _defaultButtonIndex;
     protected dstring _text;
     this(UIString caption, UIString message, Window parentWindow, dstring initialText, void delegate(dstring result) handler) {
-        super(caption, parentWindow, DialogFlag.Modal | DialogFlag.Popup);
+        super(caption, parentWindow, DialogFlag.Modal | (Platform.instance.uiDialogDisplayMode & DialogDisplayMode.inputBoxInPopup ? DialogFlag.Popup : 0));
         _message = message;
         _actions = [ACTION_OK, ACTION_CANCEL];
         _defaultButtonIndex = 0;

--- a/src/dlangui/dialogs/msgbox.d
+++ b/src/dlangui/dialogs/msgbox.d
@@ -43,7 +43,7 @@ class MessageBox : Dialog {
     protected const(Action)[] _actions;
     protected int _defaultButtonIndex;
     this(UIString caption, UIString message, Window parentWindow = null, const(Action) [] buttons = [ACTION_OK], int defaultButtonIndex = 0, bool delegate(const Action result) handler = null) {
-        super(caption, parentWindow, DialogFlag.Modal | DialogFlag.Popup);
+        super(caption, parentWindow, DialogFlag.Modal | (Platform.instance.uiDialogDisplayMode & DialogDisplayMode.messageBoxInPopup ? DialogFlag.Popup : 0));
         _message = message;
         _actions = buttons;
         _defaultButtonIndex = defaultButtonIndex;

--- a/src/dlangui/dialogs/settingsdialog.d
+++ b/src/dlangui/dialogs/settingsdialog.d
@@ -453,7 +453,7 @@ class SettingsDialog : Dialog {
     protected Setting _settings;
     protected SettingsPage _layout;
 
-    this(UIString caption, Window parent, Setting settings, SettingsPage layout, bool popup = false) {
+    this(UIString caption, Window parent, Setting settings, SettingsPage layout, bool popup = ((Platform.instance.uiDialogDisplayMode() & DialogDisplayMode.settingsDialogInPopup) == DialogDisplayMode.settingsDialogInPopup)) {
         super(caption, parent, DialogFlag.Modal | DialogFlag.Resizable | (popup?DialogFlag.Popup:0));
         _settings = settings;
         _layout = layout;

--- a/src/dlangui/platforms/common/platform.d
+++ b/src/dlangui/platforms/common/platform.d
@@ -73,6 +73,24 @@ enum WindowState : int {
     closed,
 }
 
+/// Dialog display modes - used to configure dialogs should be showed as a popup or window
+enum DialogDisplayMode : ulong {
+    /// show all types of dialogs in windows
+    allTypesOfDialogsInWindow = 0,
+    /// show file dialogs in popups
+    fileDialogInPopup = 1,
+    /// show message boxes in popups
+    messageBoxInPopup = 2,
+    /// show input boxes in popups
+    inputBoxInPopup = 4,
+    /// show settings dialogs in popups
+    settingsDialogInPopup = 8,
+    /// show user dialogs in popups - flag for user dialogs
+    userDialogInPopup = 16,
+    /// show all types of dialogs in popups
+    allTypesOfDialogsInPopup = fileDialogInPopup | messageBoxInPopup | inputBoxInPopup | settingsDialogInPopup | userDialogInPopup
+}
+
 /// Window state signal listener
 interface OnWindowStateHandler {
     /// signal listener - called when state of window is changed
@@ -1505,6 +1523,18 @@ class Platform {
         }
     }
 
+    protected ulong _uiDialogDisplayMode = DialogDisplayMode.messageBoxInPopup | DialogDisplayMode.inputBoxInPopup;
+    /// returns how dialogs should be displayed - as popup or window
+    @property ulong uiDialogDisplayMode() {
+        return _uiDialogDisplayMode;
+    }
+    
+    // sets how dialogs should be displayed - as popup or window - use DialogDisplayMode enumeration
+    @property Platform uiDialogDisplayMode(ulong newDialogDisplayMode) {
+        _uiDialogDisplayMode = newDialogDisplayMode;
+        return this;
+    }
+    
     protected string[] _resourceDirs;
     /// returns list of resource directories
     @property string[] resourceDirs() { return _resourceDirs; }

--- a/src/dlangui/platforms/console/consoleapp.d
+++ b/src/dlangui/platforms/console/consoleapp.d
@@ -69,6 +69,7 @@ class ConsolePlatform : Platform {
         _console.inputIdleEvent = &onInputIdle;
         _console.init();
         _console.setCursorType(ConsoleCursorType.Invisible);
+        _uiDialogDisplayMode = DialogDisplayMode.allTypesOfDialogsInPopup;
         _drawBuf = new ConsoleDrawBuf(_console);
     }
     ~this() {


### PR DESCRIPTION
Dialogs have very nice feature - they can be showed as popup or window. But there lack of global configuration. 
This is a proposal to add a property `uiDialogDisplayMode` to Platform class and  enumeration of types of dialogs:
- `allTypesOfDialogsInWindow =0,`
- `fileDialogInPopup = 1,`
- `messageBoxInPopup = 2,`
- `inputBoxInPopup = 4,`
- `settingsDialogInPopup = 8,`
-  `userDialogInPopup = 16 ,`
- `allTypesOfDialogsInPopup `

Default configuration is current behavior so only message and input boxes are showed as popups (`DialogDisplayMode.messageBoxInPopup | DialogDisplayMode.inputBoxInPopup`).

There will be easy way to set all dialogs show as windows (for traditional apps):
`Platform.instance.uiDialogDisplayMode = DialogDisplayMode.allTypesOfDialogsInWindow;`

Or as popups (for games):
`Platform.instance.uiDialogDisplayMode = DialogDisplayMode.allTypesOfDialogsInPopup;`

I think this will be nice future. 