### PR TITLE
Fix SDL app  on windows.

### DIFF
--- a/src/dlangui/platforms/sdl/sdlapp.d
+++ b/src/dlangui/platforms/sdl/sdlapp.d
@@ -23,7 +23,7 @@ static if (BACKEND_SDL):
 import core.runtime;
 import std.conv;
 import std.string;
-import std.utf : toUTF32;
+import std.utf : toUTF32, toUTF16z;
 import std.stdio;
 import std.algorithm;
 import std.file;


### PR DESCRIPTION
Fix compilation on windows with SDL subconfig:

> dlangui-0.9.56\dlangui\src\dlangui\platforms\
> sdl\sdlapp.d(1455,58): Error: no property 'toUTF16z' for type 'string'
> ..\..\AppData\Roaming\dub\packages\dlangui-0.9.56\dlangui\src\dlangui\platforms\
> sdl\sdlapp.d(1887,35): Error: undefined identifier 'toUTF16z'
> dmd failed with exit code 1.
> 