### PR TITLE
Fix mouse move always redraw - related to #347

### DIFF
--- a/src/dlangui/platforms/sdl/sdlapp.d
+++ b/src/dlangui/platforms/sdl/sdlapp.d
@@ -722,7 +722,7 @@ class SDLWindow : Window {
             bool res = dispatchMouseEvent(event);
             if (res) {
                 debug(mouse) Log.d("Calling update() after mouse event");
-                invalidate();
+                update();
             }
         }
     }
@@ -951,7 +951,7 @@ class SDLWindow : Window {
         bool res = dispatchKeyEvent(new KeyEvent(KeyAction.Text, 0, flags, ds));
         if (res) {
             debug(DebugSDL) Log.d("Calling update() after text event");
-            invalidate();
+            update();
         }
         return res;
     }
@@ -1026,7 +1026,7 @@ class SDLWindow : Window {
 //            }
         if (res) {
             debug(DebugSDL) Log.d("Calling update() after key event");
-            invalidate();
+            update();
         }
         return res;
     }

--- a/src/dlangui/widgets/controls.d
+++ b/src/dlangui/widgets/controls.d
@@ -211,6 +211,7 @@ class SwitchButton : Widget {
             uint st = state;
             img.drawTo(buf, rc, st);
         }
+        _needDraw = false;
     }
 }
 


### PR DESCRIPTION
This PR fix always redraw when mouse move issues, I think it fix or partially fix #347. 

Changes:
- SDL app change `invalidate()` to `update()` to check redrawn is necessary
- `SwitchButton` don't set `_needDraw` after draw so every mouse move makes redraw