### PR TITLE
Excessive item measure in ListWidget onDraw() - maybe related to #347

### DIFF
--- a/src/dlangui/widgets/lists.d
+++ b/src/dlangui/widgets/lists.d
@@ -1188,7 +1188,6 @@ class ListWidget : WidgetGroup, OnScrollHandler, OnAdapterChangeHandler {
                 Widget w = itemWidget(i);
                 if (w is null || w.visibility != Visibility.Visible)
                     continue;
-                w.measure(itemrc.width, itemrc.height);
                 w.layout(itemrc);
                 w.onDraw(buf);
             }


### PR DESCRIPTION
I made some test, and I think this measure is not necessary. Can anyone find situation when it is required? Menu uses ListWidget so maybe that reduce a little CPU usage when redraw.