### PR TITLE
Making spreadsheet.d compile by adding required import.

### DIFF
--- a/examples/spreadsheet/src/dlangui/widgets/spreadsheet.d
+++ b/examples/spreadsheet/src/dlangui/widgets/spreadsheet.d
@@ -8,6 +8,7 @@ import dlangui.widgets.controls;
 import dlangui.widgets.tabs;
 import dlangui.widgets.editors;
 import dlangui.widgets.grid;
+import dlangui.widgets.scrollbar;
 
 import std.algorithm : min;
 


### PR DESCRIPTION
Stumbled over this when trying to compile examples from dlangui-msvc.sln with visual d.