### PR TITLE
new batching implementation

### DIFF
--- a/src/dlangui/graphics/glsupport.d
+++ b/src/dlangui/graphics/glsupport.d
@@ -642,11 +642,10 @@ private void FillColor(uint color, Color[] buf_slice) {
     }
 }
 
-private float[] convertColors(uint[] cols) {
+private float[] convertColors(uint[] cols) pure nothrow {
     float[] colors;
-    colors.assumeSafeAppend();
     colors.length = cols.length * 4;
-    for (uint i = 0; i < cols.length; i++) {
+    foreach(i; 0 .. cols.length) {
         uint color = cols[i];
         float r = ((color >> 16) & 255) / 255.0;
         float g = ((color >> 8) & 255) / 255.0;
@@ -1453,6 +1452,7 @@ private final class OpenGLQueue {
 
         enum BatchType { Line = 0, Rect, Triangle, TexturedRect }
         BatchType type;
+
         Tex2D texture;
         int textureDx;
         int textureDy;
@@ -1643,7 +1643,7 @@ private final class OpenGLQueue {
     };
 
     /// make indices for rectangle (2 triangles == 6 vertexes per rect)
-    int[6] makeRectangleIndicesArray(int offset) {
+    int[6] makeRectangleIndicesArray(int offset) pure nothrow {
         int[6] indices;
         indices[0] = offset + 0;
         indices[1] = offset + 1;
@@ -1656,7 +1656,7 @@ private final class OpenGLQueue {
     }
 
     /// make indices for triangles
-    int[3] makeTriangleIndicesArray(int offset) {
+    int[3] makeTriangleIndicesArray(int offset) pure nothrow {
         int[3] indices;
         indices[0] = offset + 0;
         indices[1] = offset + 1;
@@ -1665,7 +1665,7 @@ private final class OpenGLQueue {
     }
 
     /// make indices for lines
-    int[2] makeLineIndicesArray(int offset) {
+    int[2] makeLineIndicesArray(int offset) pure nothrow {
         int[2] indices;
         indices[0] = offset + 0;
         indices[1] = offset + 1;


### PR DESCRIPTION
I made a new GL batching system. Works good, except it was not tested on legacy api, will test it later.
There is new class `OpenGLQueue`. It has a list of batch objects and one buffer with all geometry data. Queue collects draw calls from `GLDrawBuf`, converts their arguments to vertex data and save it in buffer. At the same time queue creates batch objects, which contains information about drawing operation (length of batch, offset in index buffer and texture). If the next draw call has the same type, as the previous, it uses the last batch and only increases its `length` value. At the end of frame queue flushes data: creates VBO and EBO, fills them, attaches to VAOs and draws all batches.