### PR TITLE
Fix crash when listDirectory can't access parent path. Add listDirect…

### DIFF
--- a/src/dlangui/platforms/common/startup.d
+++ b/src/dlangui/platforms/common/startup.d
@@ -113,8 +113,11 @@ version (Windows) {
 		import dlangui.core.files;
 		import std.file : DirEntry;
 		DirEntry[] entries;
-		if (!listDirectory(dir, false, true, true, ["*.ttf"], entries))
-			return null;
+        try {
+            entries = listDirectory(dir, AttrFilter.files, ["*.ttf"]);
+        } catch(Exception e) {
+            return null;
+        }
 
 		string[] res;
 		foreach(entry; entries) {


### PR DESCRIPTION
…ory overload with more sane interface, deprecate the old one. Fix FilePathPanelItem directory selection. Show error message box when FileDialog can't access directory

This PR introduces new enum - AttrFilter which used for filtering files by their attributes (not names). Maybe there's a better name, suggest others if you have ideas.