### PR TITLE
Fixes in old GL drawing

### DIFF
--- a/examples/example1/src/example1.d
+++ b/examples/example1/src/example1.d
@@ -1217,12 +1217,12 @@ static if (ENABLE_OPENGL) {
 
         /// this is OpenGLDrawableDelegate implementation
         private void doDraw(Rect windowRect, Rect rc) {
-            Log.v("GlGears: MyOpenglWidget.doDraw() draw gears");
             if (!openglEnabled) {
                 Log.v("GlGears: OpenGL is disabled");
                 return;
             }
-            _oldApi = !!glLightfv;
+            import dlangui.graphics.glsupport : glSupport;
+            _oldApi = glSupport.legacyMode;
             if (_oldApi) {
                 drawUsingOldAPI(rc);
             } else {
@@ -1238,9 +1238,7 @@ static if (ENABLE_OPENGL) {
                 _initCalled = true;
                 glxgears_init();
             }
-            Log.v("GlGears: calling reshape()");
             glxgears_reshape(rc);
-            Log.v("GlGears: calling draw()");
             glEnable(GL_LIGHTING);
             glEnable(GL_LIGHT0);
             glEnable(GL_DEPTH_TEST);
@@ -1469,14 +1467,12 @@ static if (ENABLE_OPENGL) {
         static GLfloat[4] green = [ 0.0, 0.8, 0.2, 1.0 ];
         static GLfloat[4] blue = [ 0.2, 0.2, 1.0, 1.0 ];
         
-        Log.d("GlGears: init - calling glLightfv");
         glLightfv(GL_LIGHT0, GL_POSITION, pos.ptr);
         glEnable(GL_CULL_FACE);
         glEnable(GL_LIGHTING);
         glEnable(GL_LIGHT0);
         glEnable(GL_DEPTH_TEST);
         
-        Log.d("GlGears: init - calling genlists");
         /* make the gears */
         gear1 = glGenLists(1);
         glNewList(gear1, GL_COMPILE);

--- a/src/dlangui/graphics/gldrawbuf.d
+++ b/src/dlangui/graphics/gldrawbuf.d
@@ -80,8 +80,6 @@ class GLDrawBuf : DrawBuf, GLConfigCallback {
         glSupport.beforeRenderGUI();
         _scene.draw();
         glSupport.queue.flush();
-        GLProgram.unbind();
-        glSupport.destroyBuffers();
         glSupport.flushGL();
         destroy(_scene);
         _scene = null;
@@ -836,8 +834,6 @@ public:
             glSupport.queue.flush();
             glSupport.setOrthoProjection(_windowRect, _rc);
             glSupport.clearDepthBuffer();
-            //glEnable(GL_BLEND);
-            //checkgl!glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
             _handler(_windowRect, _rc);
             glSupport.setOrthoProjection(_windowRect, _windowRect);
         }

--- a/src/dlangui/graphics/gldrawbuf.d
+++ b/src/dlangui/graphics/gldrawbuf.d
@@ -305,6 +305,13 @@ void initGLCaches() {
         glGlyphCache = new GLGlyphCache;
 }
 
+void destroyGLCaches() {
+    if (glImageCache)
+        destroy(glImageCache);
+    if (glGlyphCache)
+        destroy(glGlyphCache);
+}
+
 private abstract class GLCache
 {
     static class GLCacheItem

--- a/src/dlangui/graphics/scene/effect.d
+++ b/src/dlangui/graphics/scene/effect.d
@@ -18,7 +18,7 @@ class Effect : GLProgram {
     EffectId _id;
     string[string] _defs;
     string _defText;
-
+    
     @property ref const(EffectId) id() const { return _id; }
     this(EffectId id) {
         _id = id;
@@ -53,6 +53,7 @@ class Effect : GLProgram {
         }
         _defText = buf.dup;
         // compile shaders
+        compile();
         if (!check()) {
             Log.e("Failed to compile shaders ", _id.vertexShaderName, " ", _id.fragmentShaderName, " ", _id.definitions);
             assert(false);

--- a/src/dlangui/platforms/common/startup.d
+++ b/src/dlangui/platforms/common/startup.d
@@ -386,6 +386,10 @@ extern (C) void releaseResourcesOnAppExit() {
         imageCache = null;
     }
     FontManager.instance = null;
+    static if (ENABLE_OPENGL) {
+        import dlangui.graphics.gldrawbuf;
+        destroyGLCaches();
+    }
     
     debug {
         if (DrawBuf.instanceCount > 0) {

--- a/src/dlangui/platforms/console/consoleapp.d
+++ b/src/dlangui/platforms/console/consoleapp.d
@@ -8,6 +8,7 @@ import dlangui.platforms.common.platform;
 import dlangui.graphics.drawbuf;
 import dlangui.graphics.fonts;
 import dlangui.widgets.styles;
+import dlangui.widgets.widget;
 import dlangui.platforms.console.consolefont;
 private import dlangui.platforms.console.dconsole;
 

--- a/src/dlangui/platforms/dsfml/dsfmlapp.d
+++ b/src/dlangui/platforms/dsfml/dsfmlapp.d
@@ -76,17 +76,6 @@ class DSFMLWindow : dlangui.platforms.common.platform.Window {
 
     private void paintUsingOpenGL() {
         import derelict.opengl3.gl3;
-        import dlangui.graphics.gldrawbuf;
-        import dlangui.graphics.glsupport;
-        if (!_gl3Reloaded) {
-            DerelictGL3.reload();
-            _gl3Reloaded = true;
-            if (!glSupport.valid && !glSupport.initShaders()) {
-                Log.d("Cannot init opengl");
-                assert(0);
-            }
-        }
-
 
         glDisable(GL_DEPTH_TEST);
         glViewport(0, 0, _dx, _dy);
@@ -422,11 +411,8 @@ void initDSFMLApp() {
 
     currentTheme = createDefaultTheme();
 
-    import derelict.opengl3.gl3;
     import dlangui.graphics.glsupport;
-    DerelictGL3.load();
-    if (!_glSupport)
-        _glSupport = new GLSupport();
+    initGLSupport(false);
 
     Platform.instance.uiTheme = "theme_dark";
 }

--- a/src/dlangui/platforms/sdl/sdlapp.d
+++ b/src/dlangui/platforms/sdl/sdlapp.d
@@ -291,8 +291,8 @@ class SDLWindow : Window {
                         Log.w("OpenGL support is disabled");
                     }
                 }
-                if (success && !_glSupport) {
-                    _enableOpengl = initGLSupport(false);
+                if (success) {
+                    _enableOpengl = initGLSupport(_platform.GLVersionMajor < 3);
                     fixSize();
                 }
             }

--- a/src/dlangui/platforms/windows/winapp.d
+++ b/src/dlangui/platforms/windows/winapp.d
@@ -183,7 +183,7 @@ static if (ENABLE_OPENGL) {
                 _hGLRC = wglCreateContext(hDC);
                 if (_hGLRC) {
                     bind(hDC);
-                    bool initialized = initGLSupport(false);
+                    bool initialized = initGLSupport(Platform.instance.GLVersionMajor < 3);
                     unbind(hDC);
                     if (!initialized) {
                         uninit();
@@ -281,7 +281,7 @@ class Win32Window : Window {
             /* initialize OpenGL rendering */
             HDC hDC = GetDC(_hwnd);
 
-            if (openglEnabled || !_glSupport) {
+            if (openglEnabled) {
                 useOpengl = sharedGLContext.init(hDC);
             }
         }

--- a/src/dlangui/platforms/x11/x11app.d
+++ b/src/dlangui/platforms/x11/x11app.d
@@ -352,20 +352,11 @@ class X11Window : DWindow {
 					_enableOpengl = false;
 				} else {
 					glXMakeCurrent(x11display, cast(uint)_win, _glc);
-					if (!_gl3Reloaded) {
-						DerelictGL3.missingSymbolCallback = &gl3MissingSymFunc;
-						DerelictGL3.reload(GLVersion.GL21, GLVersion.GL40);
-						_gl3Reloaded = true;
-						if (!_glSupport)
-							_glSupport = new GLSupport(true);
-						if (!glSupport.valid && !glSupport.initShaders())
-							_enableOpengl = false;
-						glXMakeCurrent(x11display, cast(uint)_win, null);
-						if (!_enableOpengl && _glc) {
-							glXDestroyContext(x11display, _glc);
-							_glc = null;
-						}
-					}
+                    _enableOpengl = initGLSupport(_platform.GLVersionMajor < 3);
+                    if (!_enableOpengl && _glc) {
+                        glXDestroyContext(x11display, _glc);
+                        _glc = null;
+                    }
 				}
 			}
 			if (_enableOpengl) {


### PR DESCRIPTION
1. `glSupport` correctly draws with legacy flag;
2. `opengl` example works completely;
3. `example1` works with legacy context; it is needed to synchonize these two examples or just delete opengl code from the last one;
4. tested on Ubuntu Linux with Nvidia and Intel graphic cards. Need to test on Windows.