### PR TITLE
Setting new items array must reset _selectedItemIndex to -1.

### DIFF
--- a/src/dlangui/widgets/combobox.d
+++ b/src/dlangui/widgets/combobox.d
@@ -225,6 +225,7 @@ class ComboBox : ComboBoxBase {
     }
 
     @property void items(string[] itemResourceIds) {
+        _selectedItemIndex = -1;
         setAdapter(new StringListAdapter(itemResourceIds));
         if(itemResourceIds.length > 0) {
            selectedItemIndex = 0;
@@ -233,6 +234,7 @@ class ComboBox : ComboBoxBase {
     }
 
     @property void items(dstring[] items) {
+        _selectedItemIndex = -1;
         setAdapter(new StringListAdapter(items));
         if(items.length > 0) {
             if (selectedItemIndex == -1 || selectedItemIndex > items.length)
@@ -242,6 +244,7 @@ class ComboBox : ComboBoxBase {
     }
 
     @property void items(StringListValue[] items) {
+        _selectedItemIndex = -1;
         if (auto a = cast(StringListAdapter)_adapter)
             a.items = items;
         else
@@ -369,6 +372,7 @@ class IconTextComboBox : ComboBoxBase {
     }
 
     @property void items(StringListValue[] items) {
+        _selectedItemIndex = -1;
         if (auto a = cast(IconStringListAdapter)_adapter)
             a.items = items;
         else


### PR DESCRIPTION
Setting new items array must reset _selectedItemIndex to -1 because:
-  selectedItemIndex property checks:
 `if (_selectedItemIndex == index)
            return this;`
  so `itemClick()` is not called when old selected item index == new selected item index but when we changed all items it should be called
- unnecessary item state reset (related to #375)