### PR TITLE
Fix for #354 - wrongly calculated widget sizes.

### DIFF
--- a/examples/example1/src/example1.d
+++ b/examples/example1/src/example1.d
@@ -267,7 +267,11 @@ extern (C) int UIAppMain(string[] args) {
 
     // create window
     Window window = Platform.instance.createWindow("DlangUI Example 1", null, WindowFlag.Resizable, 800, 700);
-    
+    // here you can see window or content resize mode
+    //Window window = Platform.instance.createWindow("DlangUI Example 1", null, WindowFlag.Resizable, 400, 400);
+    //window.windowOrContentResizeMode = WindowOrContentResizeMode.resizeWindow;
+    //window.windowOrContentResizeMode = WindowOrContentResizeMode.scrollWindow;
+    //window.windowOrContentResizeMode = WindowOrContentResizeMode.shrinkWidgets;
     static if (true) {
         VerticalLayout contentLayout = new VerticalLayout();
 
@@ -458,6 +462,7 @@ extern (C) int UIAppMain(string[] args) {
         // most of controls example
         {
             LinearLayout controls = new VerticalLayout("controls");
+            controls.layoutHeight(FILL_PARENT);
             controls.padding = Rect(12.pointsToPixels,12.pointsToPixels,12.pointsToPixels,12.pointsToPixels);
 
             HorizontalLayout line1 = new HorizontalLayout();
@@ -548,9 +553,12 @@ extern (C) int UIAppMain(string[] args) {
 
             HorizontalLayout line4 = new HorizontalLayout();
             line4.layoutWidth(FILL_PARENT);
+            line4.layoutHeight(FILL_PARENT);
             GroupBox gbgrid = new GroupBox("grid", "StringGridWidget"d, Orientation.Horizontal);
             StringGridWidget grid = new StringGridWidget("stringgrid");
             grid.resize(12, 10);
+            gbgrid.layoutWidth(FILL_PARENT);
+            gbgrid.layoutHeight(FILL_PARENT);
             grid.layoutWidth(FILL_PARENT);
             grid.layoutHeight(FILL_PARENT);
             foreach (index, month; ["January"d, "February"d, "March"d, "April"d, "May"d, "June"d, "July"d, "August"d, "September"d, "October"d, "November"d, "December"d])

--- a/src/dlangui/platforms/common/platform.d
+++ b/src/dlangui/platforms/common/platform.d
@@ -1104,9 +1104,13 @@ class Window : CustomEventTarget {
 
     /// handle theme change: e.g. reload some themed resources
     void dispatchThemeChanged() {
+        if (_hScrollBar)
+            _hScrollBar.onThemeChanged();
+        if (_vScrollBar)
+            _vScrollBar.onThemeChanged();
         if (_mainWidget)
             _mainWidget.onThemeChanged();
-            // draw popups
+        // draw popups
         foreach(p; _popups) {
             p.onThemeChanged();
         }

--- a/src/dlangui/platforms/common/platform.d
+++ b/src/dlangui/platforms/common/platform.d
@@ -1794,7 +1794,7 @@ class Platform {
 }
 
 static if (ENABLE_OPENGL) {
-    private __gshared bool _OPENGL_ENABLED = false;
+    private __gshared bool _OPENGL_ENABLED = true;
     /// check if hardware acceleration is enabled
     @property bool openglEnabled() { return _OPENGL_ENABLED; }
     /// call on app initialization if OpenGL support is detected

--- a/src/dlangui/platforms/common/platform.d
+++ b/src/dlangui/platforms/common/platform.d
@@ -376,6 +376,19 @@ class Window : CustomEventTarget {
                         _hScrollBar.scrollEvent = delegate bool (AbstractSlider source, ScrollEvent event) {
                             if (event.action == ScrollAction.SliderMoved || event.action == ScrollAction.SliderReleased)
                                 requestLayout();
+                            else if (event.action == ScrollAction.PageUp) {
+                                source.position = max(0, source.position - _windowRect.right * 3 / 4);
+                                requestLayout();
+                            } else if (event.action == ScrollAction.PageDown) {
+                                source.position = min(source.maxValue - _windowRect.right, source.position + _windowRect.right *3 / 4);
+                                requestLayout();
+                            } else if (event.action == ScrollAction.LineUp) {
+                                source.position = max(0, source.position - _windowRect.right / 10);
+                                requestLayout();
+                            } else if (event.action == ScrollAction.LineDown) {
+                                source.position = min(source.maxValue - _windowRect.right, source.position + _windowRect.right / 10);
+                                requestLayout();
+                            }
                             return true;
                         };
                     }
@@ -403,6 +416,19 @@ class Window : CustomEventTarget {
                         _vScrollBar.scrollEvent = delegate bool (AbstractSlider source, ScrollEvent event) {
                             if (event.action == ScrollAction.SliderMoved || event.action == ScrollAction.SliderReleased)
                                 requestLayout();
+                            else if (event.action == ScrollAction.PageUp) {
+                                source.position = max(0, source.position - _windowRect.bottom * 3 / 4);
+                                requestLayout();
+                            } else if (event.action == ScrollAction.PageDown) {
+                                source.position = min(source.maxValue - _windowRect.bottom, source.position + _windowRect.bottom *3 / 4);
+                                requestLayout();
+                            } else if (event.action == ScrollAction.LineUp) {
+                                source.position = max(0, source.position - _windowRect.bottom / 10);
+                                requestLayout();
+                            } else if (event.action == ScrollAction.LineDown) {
+                                source.position = min(source.maxValue - _windowRect.bottom, source.position + _windowRect.bottom / 10);
+                                requestLayout();
+                            }
                             return true;
                         };
                     }

--- a/src/dlangui/platforms/sdl/sdlapp.d
+++ b/src/dlangui/platforms/sdl/sdlapp.d
@@ -350,16 +350,15 @@ class SDLWindow : Window {
             Log.e("Window is shown without main widget");
             _mainWidget = new Widget();
         }
-        if (_mainWidget && !(_flags & WindowFlag.Resizable)) {
+        if (_mainWidget) {
             _mainWidget.measure(SIZE_UNSPECIFIED, SIZE_UNSPECIFIED);
-            SDL_SetWindowSize(_win, _mainWidget.measuredWidth, _mainWidget.measuredHeight);
+            adjustWindowOrContentSize(_mainWidget.measuredWidth, _mainWidget.measuredHeight);
         }
+            
         SDL_ShowWindow(_win);
         if (_mainWidget)
             _mainWidget.setFocus();
         fixSize();
-        //update(true);
-        //redraw();
         SDL_RaiseWindow(_win);
         invalidate();
     }

--- a/src/dlangui/platforms/windows/winapp.d
+++ b/src/dlangui/platforms/windows/winapp.d
@@ -432,17 +432,13 @@ class Win32Window : Window {
             _mainWidget = new Widget();
         }
         ReleaseCapture();
-        if (!(_flags & WindowFlag.Resizable) && _mainWidget) {
+        
+        if (_mainWidget) {
             _mainWidget.measure(SIZE_UNSPECIFIED, SIZE_UNSPECIFIED);
-            int dx = _mainWidget.measuredWidth;
-            int dy = _mainWidget.measuredHeight;
-            dx += 2 * GetSystemMetrics(SM_CXDLGFRAME);
-            dy += GetSystemMetrics(SM_CYCAPTION) + 2 * GetSystemMetrics(SM_CYDLGFRAME);
-            // TODO: ensure size less than screen size
-            SetWindowPos(_hwnd, HWND_TOP, 0, 0, dx, dy, SWP_NOMOVE| SWP_SHOWWINDOW);
-        } else {
-            ShowWindow(_hwnd, SW_SHOWNORMAL);
+            adjustWindowOrContentSize(_mainWidget.measuredWidth, _mainWidget.measuredHeight);
         }
+        
+        ShowWindow(_hwnd, SW_SHOWNORMAL);
         if (_mainWidget)
             _mainWidget.setFocus();
         SetFocus(_hwnd);

--- a/src/dlangui/platforms/x11/x11app.d
+++ b/src/dlangui/platforms/x11/x11app.d
@@ -428,8 +428,13 @@ class X11Window : DWindow {
 				Log.d("Open GL support is disabled");
 			}
 		}
-		if (_mainWidget)
-			_mainWidget.setFocus();
+        if (_mainWidget) {
+            _mainWidget.measure(SIZE_UNSPECIFIED, SIZE_UNSPECIFIED);
+            _windowRect.right = _dx;// hack to set windowRect, remove when _windowRect will be full supported on X11
+            _windowRect.bottom = _dy;
+            adjustWindowOrContentSize(_mainWidget.measuredWidth, _mainWidget.measuredHeight);
+            _mainWidget.setFocus();
+        }
 	}
 
 	protected final void changeWindowState(int action, Atom firstProperty, Atom secondProperty = None) nothrow

--- a/src/dlangui/platforms/x11/x11app.d
+++ b/src/dlangui/platforms/x11/x11app.d
@@ -1542,6 +1542,13 @@ class X11Platform : Platform {
 			w.requestLayout();
 		}
 	}
+    
+    /// handle theme change: e.g. reload some themed resources
+    override void onThemeChanged() {
+        foreach(w; _windowMap)
+            w.dispatchThemeChanged();
+    }
+    
 }
 
 import core.thread;

--- a/src/dlangui/widgets/editors.d
+++ b/src/dlangui/widgets/editors.d
@@ -1899,6 +1899,10 @@ class EditLine : EditWidgetBase {
     protected dstring _measuredText;
     protected int[] _measuredTextWidths;
     protected Point _measuredTextSize;
+    
+    protected Point _measuredTextToSetWidgetSize;
+    protected dstring _textToSetWidgetSize = "aaaaa"d;
+    protected int[] _measuredTextToSetWidgetSizeWidths;
 
     protected dchar _passwordChar = 0;
     /// password character - 0 for normal editor, some character, e.g. '*' to hide text by replacing all characters with this char
@@ -1972,17 +1976,27 @@ class EditLine : EditWidgetBase {
         //Point sz = font.textSize(text);
         _measuredText = applyPasswordChar(text);
         _measuredTextWidths.length = _measuredText.length;
-        int charsMeasured = font.measureText(_measuredText, _measuredTextWidths, int.max, tabSize);
+        int charsMeasured = font.measureText(_measuredText, _measuredTextWidths, MAX_WIDTH_UNSPECIFIED, tabSize);
         _measuredTextSize.x = charsMeasured > 0 ? _measuredTextWidths[charsMeasured - 1]: 0;
         _measuredTextSize.y = font.height;
         return _measuredTextSize;
+    }
+    
+    protected Point measureTextToSetWidgetSize() {
+        FontRef font = font();
+        _measuredTextToSetWidgetSizeWidths.length = _textToSetWidgetSize.length;
+        int charsMeasured = font.measureText(_textToSetWidgetSize, _measuredTextToSetWidgetSizeWidths, MAX_WIDTH_UNSPECIFIED, tabSize);
+        _measuredTextToSetWidgetSize.x = charsMeasured > 0 ? _measuredTextToSetWidgetSizeWidths[charsMeasured - 1]: 0;
+        _measuredTextToSetWidgetSize.y = font.height;
+        return _measuredTextToSetWidgetSize;
     }
 
     /// measure
     override void measure(int parentWidth, int parentHeight) { 
         updateFontProps();
         measureVisibleText();
-        measuredContent(parentWidth, parentHeight, _measuredTextSize.x + _leftPaneWidth, _measuredTextSize.y);
+        measureTextToSetWidgetSize();
+        measuredContent(parentWidth, parentHeight, _measuredTextToSetWidgetSize.x + _leftPaneWidth, _measuredTextToSetWidgetSize.y);
     }
 
     override bool handleAction(const Action a) {
@@ -2128,6 +2142,10 @@ class EditBox : EditWidgetBase {
     protected int[] _visibleLinesWidths; // width (in pixels) of visible lines
     protected CustomCharProps[][] _visibleLinesHighlights;
     protected CustomCharProps[][] _visibleLinesHighlightsBuf;
+    
+    protected Point _measuredTextToSetWidgetSize; 
+    protected dstring _textToSetWidgetSize = "aaaaa/naaaaa"d;
+    protected int[] _measuredTextToSetWidgetSizeWidths;
 
     override protected int lineCount() {
         return _content.length;
@@ -2641,6 +2659,16 @@ class EditBox : EditWidgetBase {
         return textSz;
     }
 
+    // override to set minimum scrollwidget size - default 100x100
+    override protected Point minimumVisibleContentSize() {
+        FontRef font = font();
+        _measuredTextToSetWidgetSizeWidths.length = _textToSetWidgetSize.length;
+        int charsMeasured = font.measureText(_textToSetWidgetSize, _measuredTextToSetWidgetSizeWidths, MAX_WIDTH_UNSPECIFIED, tabSize);
+        _measuredTextToSetWidgetSize.x = charsMeasured > 0 ? _measuredTextToSetWidgetSizeWidths[charsMeasured - 1]: 0;
+        _measuredTextToSetWidgetSize.y = font.height;
+        return _measuredTextToSetWidgetSize;
+    }
+    
     /// measure
     override void measure(int parentWidth, int parentHeight) { 
         if (visibility == Visibility.Gone) {
@@ -2657,8 +2685,6 @@ class EditBox : EditWidgetBase {
         }
 
         super.measure(parentWidth, parentHeight);
-        // do we need to add vsbwidth, hsbheight ???
-        //measuredContent(parentWidth, parentHeight, textSz.x + vsbwidth, textSz.y + hsbheight);
     }
 
 

--- a/src/dlangui/widgets/grid.d
+++ b/src/dlangui/widgets/grid.d
@@ -1533,6 +1533,29 @@ class GridWidgetBase : ScrollWidgetBase, GridModelAdapter, MenuItemActionHandler
             sz.y += _rowHeights[i];
         return sz;
     }
+    
+    /// calculate minimum size of widget
+    override Point minimumVisibleContentSize() {
+        Point sz;
+        if (_cols == 0 || _rows == 0) {
+             sz.x = 100;
+             sz.y = 100;
+             return sz;
+        }
+        // width:
+        if (_cols < 2)
+            sz.x = _colWidths[0];
+        else
+            sz.x = _colWidths[0] + _colWidths[1];
+        
+        // height
+        if (_rows < 2)
+            sz.y = _rowHeights[0];
+        else
+            sz.y = _rowHeights[0] + _rowHeights[1];
+                
+        return sz;
+    }
 
     override protected void drawClient(DrawBuf buf) {
         if (!_cols || !_rows)

--- a/src/dlangui/widgets/lists.d
+++ b/src/dlangui/widgets/lists.d
@@ -942,6 +942,11 @@ class ListWidget : WidgetGroup, OnScrollHandler, OnAdapterChangeHandler {
         if (_adapter)
             _adapter.onThemeChanged();
     }
+    
+    /// sets minimum size for the list, override to change
+    Point minimumVisibleContentSize() {
+        return Point(100, 100);
+    }
 
     /// Measure widget according to desired width and height constraints. (Step 1 of two phase layout).
     override void measure(int parentWidth, int parentHeight) {
@@ -953,6 +958,15 @@ class ListWidget : WidgetGroup, OnScrollHandler, OnAdapterChangeHandler {
             _itemSizes.length = itemCount;
         Rect m = margins;
         Rect p = padding;
+        
+        // set widget area to small when first measure
+        if (parentWidth == SIZE_UNSPECIFIED && parentHeight == SIZE_UNSPECIFIED)
+        {
+            Point sz = minimumVisibleContentSize;
+            measuredContent(parentWidth, parentHeight, sz.x, sz.y);
+            return;
+        }
+        
         // calc size constraints for children
         int pwidth = parentWidth;
         int pheight = parentHeight;
@@ -1041,6 +1055,7 @@ class ListWidget : WidgetGroup, OnScrollHandler, OnAdapterChangeHandler {
             }
         }
         measuredContent(parentWidth, parentHeight, sz.x + _sbsz.x, sz.y + _sbsz.y);
+
         if (_scrollbar.visibility == oldScrollbarVisibility) {
             _needLayout = oldNeedLayout;
             _scrollbar.cancelLayout();

--- a/src/dlangui/widgets/scroll.d
+++ b/src/dlangui/widgets/scroll.d
@@ -273,6 +273,11 @@ class ScrollWidgetBase :  WidgetGroup, OnScrollHandler {
         return sz;
     }
 
+    // override to set minimum scrollwidget size - default 100x100
+    Point minimumVisibleContentSize() {
+        return Point(100,100);
+    }
+
     /// Measure widget according to desired width and height constraints. (Step 1 of two phase layout).
     override void measure(int parentWidth, int parentHeight) { 
         if (visibility == Visibility.Gone) {
@@ -280,6 +285,7 @@ class ScrollWidgetBase :  WidgetGroup, OnScrollHandler {
         }
         Rect m = margins;
         Rect p = padding;
+        
         // calc size constraints for children
         int pwidth = parentWidth;
         int pheight = parentHeight;
@@ -293,13 +299,14 @@ class ScrollWidgetBase :  WidgetGroup, OnScrollHandler {
         if (_vscrollbar && _vscrollbarMode == ScrollBarMode.Visible) {
             _vscrollbar.measure(pwidth, pheight);
         }
-        Point sz = fullContentSize();
+        Point sz = minimumVisibleContentSize();
         if (_hscrollbar && _hscrollbarMode == ScrollBarMode.Visible) {
             sz.y += _hscrollbar.measuredHeight;
         }
         if (_vscrollbar && _vscrollbarMode == ScrollBarMode.Visible) {
             sz.x += _vscrollbar.measuredWidth;
         }
+
         measuredContent(parentWidth, parentHeight, sz.x, sz.y);
     }
 

--- a/src/dlangui/widgets/tree.d
+++ b/src/dlangui/widgets/tree.d
@@ -813,6 +813,10 @@ class TreeWidgetBase :  ScrollWidget, OnTreeContentChangeListener, OnTreeStateCh
         super.layout(rc);
     }
 
+    override Point minimumVisibleContentSize() {
+        return Point(200,200);
+    }
+
     /// Measure widget according to desired width and height constraints. (Step 1 of two phase layout).
     override void measure(int parentWidth, int parentHeight) { 
         if (visibility == Visibility.Gone) {


### PR DESCRIPTION
This PR improve DlangUI widgets measure and window content support. Now it's possible to do something like this:

![dlangui_scrollwindow](https://user-images.githubusercontent.com/18555708/27517321-e39ad40e-59ca-11e7-8071-3c68f559b296.png)

# Widget measure
This can't be done without change some widget measure behavior. Now widgets are increasing when has FILL_PARENT flags - not shrinking to window size.  We must measure widget size not content size for some of widgets like `Grid`, `TreeView`, `EditBox`, `EditLine`. Most of this widgets need optimizations - content size can be measured only when content is changed. I don't do that in this PR.

### ScrollWidgetBase and inherited
I added `minimumVisibleContentSize()` which is used to get minimal sensible size.
### EditLine
I deliberated long time how to do it. And I think the best way is to get width and height of some standard text. I used "aaaaa" but there is `_textToSetWidgetSize` and in the future we can add property to set it to something else. Using string gives certainty that changing font will make widget enough big.

That fixes not only getting minimal size but also widget don't grow when you write letters in some cases (for example when there are 2 widgets in horizontal layout with `FILL_PARENT` flag in one line).

### EditBox 
Analogous to `EditLine` but it uses "aaaaa/naaaaa". There should be minimum 2 lines of text.

### ListWidget
This is a little tricky because it is used for menu. First measure returns 100,100 second measure returns real size (only because of menu). 

# WindowOrContentResizeMode enum
I not found better name, maybe someone gives something shorter. 
There are three algorithms:
- `shrinkWidgets` - something like in previous version of DlangUI
- `resizeWindow` - window is resized to fit content (not working in X11 now because `Window.windowResize()` is not implemented in X11
- `scrollWindow` - now default, if widgets are bigger than window adds scrollbars to window

# Warnings
1. I tested this solution on Linux and Windows (X11, SDL, win32 platforms).
2. Tested with example1, DlangIDE and my own project
3. Some windows may need some tweaks because now widgets are increasing when has FILL_PARENT flags not shrinking to window size. Usually some layouts needs set FILL_PARENT flag.
4. Need more tests.

# Extra fixes
Fixed theme change on X11.
