### PR TITLE
improve travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,12 @@ matrix:
     - os: osx
       env: ARCH=x86_64 CONFIG=x11
 
-sudo: true
-before_script:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$ARCH" == "x86" ]]; then sudo apt-get install gcc-multilib; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$CONFIG" == "x11" && "$ARCH" == "x86_64" ]]; then sudo apt-get install libx11-dev; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$CONFIG" == "x11" && "$ARCH" == "x86" ]]; then sudo apt-get install libx11-dev:i386; fi
+addons:
+  apt:
+    packages:
+      - gcc-multilib
+      - libx11-dev
+      - libx11-dev:i386
 
 script:
   - dub test --compiler=${DC} --arch=${ARCH} --config=${CONFIG}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: trusty
 
 language: d
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 language: d
 
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ d:
   - dmd-beta
   - ldc
   - ldc-beta
-  - gdc-6.3.0
 
 env:
   - ARCH=x86_64 CONFIG=default
@@ -30,8 +29,6 @@ matrix:
       env: ARCH=x86 CONFIG=x11
     - os: osx
       env: ARCH=x86_64 CONFIG=x11
-    - os: osx
-      d: gdc-6.3.0
 
 sudo: true
 before_script:


### PR DESCRIPTION
gdc isn't going to work.

using `sudo: false` should (in theory) result in faster tests as it will use the containerised environments, which start faster.

updating to trusty is just generally a good idea seeing as precise is no longer supported by canonical.