### PR TITLE
Show popup need window update.

### DIFF
--- a/src/dlangui/platforms/common/platform.d
+++ b/src/dlangui/platforms/common/platform.d
@@ -645,6 +645,7 @@ class Window : CustomEventTarget {
         if (_mainWidget !is null) {
             _mainWidget.requestLayout();
         }
+        update(false);
         return res;
     }
     /// remove popup


### PR DESCRIPTION
Sometimes changing window size is needed to show popup. 

You can see that bug in example1.Try File->Open choose two files and click Open. Popups need change window size to appear. 