### PR TITLE
Measure fixes and improvments

### DIFF
--- a/src/dlangui/dialogs/dialog.d
+++ b/src/dlangui/dialogs/dialog.d
@@ -208,6 +208,8 @@ class Dialog : VerticalLayout {
             _popup = _parentWindow.showPopup(_frame);
             _popup.flags(PopupFlags.Modal);
         } else {
+            if (_initialWidth == 0 && _initialHeight == 0)
+                wflags |= WindowFlag.MeasureSize;
             _window = Platform.instance.createWindow(_caption, _parentWindow, wflags, _initialWidth, _initialHeight);
             static if (BACKEND_GUI) {
                 if (_window && _icon)

--- a/src/dlangui/dialogs/filedlg.d
+++ b/src/dlangui/dialogs/filedlg.d
@@ -600,6 +600,8 @@ class FileDialog : Dialog, CustomGridCellAdapter {
         _fileList.multiSelect = _allowMultipleFiles;
         _fileList.cellPopupMenu = &getCellPopupMenu;
         _fileList.menuItemAction = &handleAction;
+        _fileList.minVisibleRows = 10;
+        _fileList.minVisibleCols = 4;
 
         _fileList.keyEvent = delegate(Widget source, KeyEvent event) {
             if (_shortcutHelper.onKeyEvent(event))
@@ -766,13 +768,15 @@ class FilePathPanelButtons : WidgetGroupDefaultDrawing {
     override void measure(int parentWidth, int parentHeight) { 
         Rect m = margins;
         Rect p = padding;
+        
         // calc size constraints for children
-        int pwidth = parentWidth;
-        int pheight = parentHeight;
+        int pwidth = 0;
+        int pheight = 0;
         if (parentWidth != SIZE_UNSPECIFIED)
-            pwidth -= m.left + m.right + p.left + p.right;
+            pwidth = parentWidth - (m.left + m.right + p.left + p.right);
+            
         if (parentHeight != SIZE_UNSPECIFIED)
-            pheight -= m.top + m.bottom + p.top + p.bottom;
+            pheight = parentHeight - (m.top + m.bottom + p.top + p.bottom);
         int reservedForEmptySpace = parentWidth / 20;
         if (reservedForEmptySpace > 40.pointsToPixels)
             reservedForEmptySpace = 40.pointsToPixels;
@@ -785,17 +789,14 @@ class FilePathPanelButtons : WidgetGroupDefaultDrawing {
         bool exceeded = false;
         for (int i = 0; i < _children.count; i++) {
             Widget item = _children.get(i);
-            item.visibility = Visibility.Visible;
             item.measure(pwidth, pheight);
             if (sz.y < item.measuredHeight)
                 sz.y = item.measuredHeight;
             if (sz.x + item.measuredWidth > pwidth) {
                 exceeded = true;
             }
-            if (!exceeded || i == 0) // at least one item must be visible
+            if (!exceeded || i == 0) // at least one item must be measured
                 sz.x += item.measuredWidth;
-            else
-                item.visibility = Visibility.Gone;
         }
         measuredContent(parentWidth, parentHeight, sz.x, sz.y);
     }

--- a/src/dlangui/platforms/common/platform.d
+++ b/src/dlangui/platforms/common/platform.d
@@ -52,6 +52,8 @@ enum WindowFlag : uint {
     Fullscreen = 2,
     /// modal window - grabs input focus
     Modal = 4,
+    /// measure window size on window.show() - helps if you want scrollWindow but on show() you want to set window to mainWidget measured size
+    MeasureSize = 8,
 }
 
 /// Window states

--- a/src/dlangui/platforms/sdl/sdlapp.d
+++ b/src/dlangui/platforms/sdl/sdlapp.d
@@ -399,8 +399,17 @@ class SDLWindow : Window {
                 res = true;
                 break;
             case WindowState.normal:
-                if (_windowState != WindowState.normal) 
+                if (_windowState != WindowState.normal) {
                     SDL_RestoreWindow(_win);
+                    version(linux) {
+                        // some SDL versions, reset windows size and position to values from create window (SDL 2.0.4) on linux (don't know how it works on macOS)
+                        if (newWindowRect.bottom == int.min && newWindowRect.right == int.min)
+                            SDL_SetWindowSize(_win, _windowRect.right, _windowRect.bottom);
+                        
+                        if (newWindowRect.top == int.min && newWindowRect.left == int.min)
+                            SDL_SetWindowPosition(_win, _windowRect.left, _windowRect.top);
+                    }
+                }
                 res = true;
                 break;
             default:

--- a/src/dlangui/platforms/sdl/sdlapp.d
+++ b/src/dlangui/platforms/sdl/sdlapp.d
@@ -352,6 +352,9 @@ class SDLWindow : Window {
         }
         if (_mainWidget) {
             _mainWidget.measure(SIZE_UNSPECIFIED, SIZE_UNSPECIFIED);
+            if (flags & WindowFlag.MeasureSize) {
+                resizeWindow(Point(_mainWidget.measuredWidth, _mainWidget.measuredHeight));
+            }
             adjustWindowOrContentSize(_mainWidget.measuredWidth, _mainWidget.measuredHeight);
         }
             

--- a/src/dlangui/platforms/windows/winapp.d
+++ b/src/dlangui/platforms/windows/winapp.d
@@ -432,9 +432,10 @@ class Win32Window : Window {
             _mainWidget = new Widget();
         }
         ReleaseCapture();
-        
         if (_mainWidget) {
             _mainWidget.measure(SIZE_UNSPECIFIED, SIZE_UNSPECIFIED);
+            if (flags & WindowFlag.MeasureSize)
+                resizeWindow(Point(_mainWidget.measuredWidth, _mainWidget.measuredHeight));
             adjustWindowOrContentSize(_mainWidget.measuredWidth, _mainWidget.measuredHeight);
         }
         

--- a/src/dlangui/platforms/windows/winapp.d
+++ b/src/dlangui/platforms/windows/winapp.d
@@ -488,26 +488,34 @@ class Win32Window : Window {
                         default:
                             break;
                     }
+                    res = true;
                 }
-                return true;
+                break;
             case WindowState.maximized:
-                if (_windowState != WindowState.maximized || activate)
+                if (_windowState != WindowState.maximized || activate) {
                     ShowWindow(_hwnd, activate ? SW_SHOWMAXIMIZED : SW_MAXIMIZE);
-                return true;
+                    res = true;
+                }
+                break;
             case WindowState.minimized:
-                if (_windowState != WindowState.minimized || activate)
+                if (_windowState != WindowState.minimized || activate) {
                     ShowWindow(_hwnd, activate ? SW_SHOWMINIMIZED : SW_MINIMIZE);
-                return true;
+                    res = true;
+                }
+                break;
             case WindowState.hidden:
-                if (_windowState != WindowState.hidden)
+                if (_windowState != WindowState.hidden) {
                     ShowWindow(_hwnd, SW_HIDE);
-                return true;
-            case WindowState.normal:
+                    res = true;
+                }
+                break;
+            case WindowState.normal: 
                 if (_windowState != WindowState.normal || activate) {
                     ShowWindow(_hwnd, activate ? SW_SHOWNORMAL : SW_SHOWNA); // SW_RESTORE
+                    res = true;
                 }
-                res = true;
                 break;
+
             default:
                 break;
         }
@@ -520,13 +528,13 @@ class Win32Window : Window {
                 // no position specified
                 if (newWindowRect.bottom != int.min && newWindowRect.right != int.min) {
                     // change size only
-                    SetWindowPos(_hwnd, NULL, 0, 0, newWindowRect.right, newWindowRect.bottom, flags | SWP_NOMOVE);
+                    SetWindowPos(_hwnd, NULL, 0, 0, newWindowRect.right + 2 * GetSystemMetrics(SM_CXDLGFRAME), newWindowRect.bottom + GetSystemMetrics(SM_CYCAPTION) + 2 * GetSystemMetrics(SM_CYDLGFRAME), flags | SWP_NOMOVE);
                     return true;
                 }
             } else {
                 if (newWindowRect.bottom != int.min && newWindowRect.right != int.min) {
                     // change size and position
-                    SetWindowPos(_hwnd, NULL, newWindowRect.left, newWindowRect.top, newWindowRect.width, newWindowRect.height, flags);
+                    SetWindowPos(_hwnd, NULL, newWindowRect.left, newWindowRect.top, newWindowRect.right + 2 * GetSystemMetrics(SM_CXDLGFRAME), newWindowRect.bottom + GetSystemMetrics(SM_CYCAPTION) + 2 * GetSystemMetrics(SM_CYDLGFRAME), flags);
                     return true;
                 } else {
                     // change position only

--- a/src/dlangui/platforms/x11/x11app.d
+++ b/src/dlangui/platforms/x11/x11app.d
@@ -430,6 +430,8 @@ class X11Window : DWindow {
 		}
         if (_mainWidget) {
             _mainWidget.measure(SIZE_UNSPECIFIED, SIZE_UNSPECIFIED);
+            if (flags & WindowFlag.MeasureSize)
+                resizeWindow(Point(_mainWidget.measuredWidth, _mainWidget.measuredHeight));
             _windowRect.right = _dx;// hack to set windowRect, remove when _windowRect will be full supported on X11
             _windowRect.bottom = _dy;
             adjustWindowOrContentSize(_mainWidget.measuredWidth, _mainWidget.measuredHeight);

--- a/src/dlangui/widgets/grid.d
+++ b/src/dlangui/widgets/grid.d
@@ -59,7 +59,7 @@ import dlangui.widgets.scroll;
 import dlangui.widgets.menu;
 import std.conv;
 import std.container.rbtree;
-import std.algorithm : equal;
+import std.algorithm : equal, min;
 
 /// cellPopupMenu signal handler interface
 interface CellPopupMenuHandler {
@@ -1534,6 +1534,32 @@ class GridWidgetBase : ScrollWidgetBase, GridModelAdapter, MenuItemActionHandler
         return sz;
     }
     
+    protected int _minVisibleCols = 2;
+    protected int _minVisibleRows = 2;
+
+    /// returns number of columns from 0 that are taken to measure minimum visible width
+    @property int minVisibleCols() {
+        return _minVisibleCols;
+    }
+
+    /// sets number of columns from 0 that are taken to measure minimum visible width
+    @property void minVisibleCols(int newMinVisibleCols) {
+        _minVisibleCols = newMinVisibleCols;
+        requestLayout();
+    }
+    
+    /// returns number of rows from 0 that are taken to measure minimum visible height
+    @property int minVisibleRows() {
+        return _minVisibleRows;
+    }
+
+    /// sets number of rows from 0 that are taken to measure minimum visible height, if there are too little rows last row height is multiplied
+    @property void minVisibleRows(int newMinVisibleRows) {
+        _minVisibleRows = newMinVisibleRows;
+        requestLayout();
+    }
+        
+    
     /// calculate minimum size of widget
     override Point minimumVisibleContentSize() {
         Point sz;
@@ -1542,18 +1568,18 @@ class GridWidgetBase : ScrollWidgetBase, GridModelAdapter, MenuItemActionHandler
              sz.y = 100;
              return sz;
         }
+        
         // width:
-        if (_cols < 2)
-            sz.x = _colWidths[0];
-        else
-            sz.x = _colWidths[0] + _colWidths[1];
+        for (int i = 0 ; i < min(_cols, _minVisibleCols) ; i++)
+            sz.x += _colWidths[i];
         
         // height
-        if (_rows < 2)
-            sz.y = _rowHeights[0];
-        else
-            sz.y = _rowHeights[0] + _rowHeights[1];
-                
+        for (int i = 0 ; i < min(_rows, _minVisibleRows) ; i++)
+            sz.y += _rowHeights[i];
+            
+        if (_rows<_minVisibleRows)
+            sz.y += (_minVisibleRows - _rows) * _rowHeights[_rows-1];
+                                
         return sz;
     }
 


### PR DESCRIPTION
Next measure PR :)
- add `MeasureSize` flag to window, useful when you want window with scrollbars but on show just adapt window size to content size.
- all dialogs fixed, now in dlangide preferences shows without horizontal scrollbars, file dialog fixed too
- restore window in SDL (2.0.4 on linux) reset position and size to window initial. So after restore we must set it
- SDL can't resize window to size with frame, so I modified windows version to works like SDL, fix function never goes to resize code
- ability to set how many cols/rows sets minimum widget size, use example in file dialog