### PR TITLE
Ability to center child windows on parent, other fixes

### DIFF
--- a/src/dlangui/platforms/android/androidapp.d
+++ b/src/dlangui/platforms/android/androidapp.d
@@ -33,6 +33,10 @@ class AndroidWindow : Window {
 	}
 	bool _visible;
 
+    override @property Window parentWindow() {
+        return null;
+    }
+    
 	protected dstring _caption;
 	/// returns window caption
 	override @property dstring windowCaption() {

--- a/src/dlangui/platforms/console/consoleapp.d
+++ b/src/dlangui/platforms/console/consoleapp.d
@@ -52,6 +52,11 @@ class ConsoleWindow : Window {
         Log.d("ConsoleWindow.close()");
         _platform.closeWindow(this);
     }
+    
+    override @property Window parentWindow() {
+        return _parent;
+    }
+
     protected bool _visible;
     /// returns true if window is shown
     @property bool visible() {

--- a/src/dlangui/platforms/x11/x11app.d
+++ b/src/dlangui/platforms/x11/x11app.d
@@ -512,6 +512,10 @@ class X11Window : DWindow {
 		return result;
 	}
 
+    override @property DWindow parentWindow() {
+        return _parent;
+    }
+    
 	override @property dstring windowCaption() {
 		return _caption;
 	}


### PR DESCRIPTION
Before this PR when I open second window it's placed on random position, this PR makes child windows are placed on parent center. For example "New folder" dialog looks a lot better:

![centered_dialogs](https://user-images.githubusercontent.com/18555708/28887127-4f3ccad2-77bc-11e7-8687-e463e15bb6c1.png)

### How it works?
I added `ShowPosition` enum current with two values (`dontCare` or `parentWindowCenter`). Behavior can be changed by `showPosition` property. Child windows are centered by default.

### Abstract Window changes:
1. Added abstract `windowParent()` property
2. Improved checks  in `handleWindowStateChange()`

### SDL fixes:
1. Changing window state handle must be called in setWindowState() not only in events - fixes immediately use of `windowRect` after you change window size from api.
2. Call `adjustWindowOrContentSize()` is not necessary when `WindowFlag.MeasureSize` is set
3. Implemented `windowParent()` property

### Windows fixes:
1. Call `handleWindowStateChange()` on window state/size/position change (maybe fixes #394)
2. `setWindowState()` fixes (like in SDL)
3. Set window state/rect on window create.
4. Call `adjustWindowOrContentSize()` is not necessary when `WindowFlag.MeasureSize` is set
5. Implemented `windowParent()` property