### PR TITLE
Fix failure in unittest on Windows systems

### DIFF
--- a/src/dlangui/platforms/common/platform.d
+++ b/src/dlangui/platforms/common/platform.d
@@ -1896,16 +1896,19 @@ mixin template APP_ENTRY_POINT() {
     } else {
         /// workaround for link issue when WinMain is located in library
         version(Windows) {
-            extern (Windows) int WinMain(void* hInstance, void* hPrevInstance,
-                                         char* lpCmdLine, int nCmdShow)
-            {
-                try {
-                    int res = DLANGUIWinMain(hInstance, hPrevInstance,
-                                             lpCmdLine, nCmdShow);
-                    return res;
-                } catch (Exception e) {
-                    Log.e("Exception: ", e);
-                    return 1;
+            version (unittest) {
+            } else {
+                extern (Windows) int WinMain(void* hInstance, void* hPrevInstance,
+                                             char* lpCmdLine, int nCmdShow)
+                {
+                    try {
+                        int res = DLANGUIWinMain(hInstance, hPrevInstance,
+                                                 lpCmdLine, nCmdShow);
+                        return res;
+                    } catch (Exception e) {
+                        Log.e("Exception: ", e);
+                        return 1;
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
Currently `dub test` command fails on Windows systems with the error message:

```
src\dlangui\platforms\common\platform.d(1899,34): Error: only one main/WinMain/DllMain allowed. Previously found main at ..\..\Users\appveyor\AppData\Local\Temp\1\dub_test_root-670c8bab-35df-4b13-8944-660c4cffbb30.d(136,12)
```

This request fixes this issue by enclosing `WinMain` with unittest else block.
