### PR TITLE
StringListWidget item highlight via values from keys

### DIFF
--- a/src/dlangui/widgets/lists.d
+++ b/src/dlangui/widgets/lists.d
@@ -1452,6 +1452,7 @@ class StringListWidget : ListWidget {
 
             if (timePassed > 0.5) _searchString = ""d;
             _searchString ~= to!dchar(event.text.toUTF8);
+            _stopWatch.reset;
 
             if ( selectClosestMatch(_searchString) ) {
                 invalidate();


### PR DESCRIPTION
The modification below allows users to find items in a list by typing with their keyboard. So, given a list with items [a, b, c]. If the user hits 'a' with their keyboard then the 'a' item will be highlighted. It also allows item selection of more complex items in list (ie list with [hello, world, mate]), and currently ignores upper case. Likely needs adjustment on the timing ("if (timePassed > 0.5) _searchString = ""d;")