### PR TITLE
ExpandSize flag - another #466 fix

### DIFF
--- a/src/dlangui/platforms/common/platform.d
+++ b/src/dlangui/platforms/common/platform.d
@@ -56,6 +56,8 @@ enum WindowFlag : uint {
     MeasureSize = 8,
     /// window without decorations
     Borderless = 16,
+    /// expand window size if main widget minimal size is greater than size defined in window constructor
+    ExpandSize = 32,
 }
 
 /// Window states
@@ -466,7 +468,7 @@ class Window : CustomEventTarget {
     void adjustWindowOrContentSize(int minContentWidth, int minContentHeight) {
         _minContentWidth = minContentWidth;
         _minContentHeight = minContentHeight;
-        if (_windowOrContentResizeMode == WindowOrContentResizeMode.resizeWindow)
+        if (_windowOrContentResizeMode == WindowOrContentResizeMode.resizeWindow || flags & WindowFlag.ExpandSize)
             resizeWindow(Point(max(_windowRect.right, minContentWidth), max(_windowRect.bottom, minContentHeight)));
         updateWindowOrContentSize();
     }


### PR DESCRIPTION
Current default window resize mode (`WindowOrContentResizeMode.resizeWindow`) ignores size settings defined in constructor. I think default behavior should not change size but add scrollbars. But that makes a problem: "How to make scrollbar window that expand size on first show?" 

First I suggested using `WindowFlag.MeasureSize` but this is most usable for dialogs and can change window size to smaller. So I propose to add `WindowFlag.ExpandSize` which will expand window size when it's too small for main widget but when user change window size to smaller there will be scrollbars not shrinked widgets. 

Please test and give me feedback if there are some situations when that is not enough.
