### PR TITLE
Linear gradients as background

### DIFF
--- a/src/dlangui/graphics/colors.d
+++ b/src/dlangui/graphics/colors.d
@@ -195,7 +195,7 @@ uint blendARGB(uint dst, uint src, uint alpha) pure nothrow {
     uint dstr = (dst >> 16) & 0xFF;
     uint dstg = (dst >> 8) & 0xFF;
     uint dstb = (dst >> 0) & 0xFF;
-    uint ialpha = 256 - alpha;
+    uint ialpha = 255 - alpha;
     uint r = ((srcr * ialpha + dstr * alpha) >> 8) & 0xFF;
     uint g = ((srcg * ialpha + dstg * alpha) >> 8) & 0xFF;
     uint b = ((srcb * ialpha + dstb * alpha) >> 8) & 0xFF;

--- a/src/dlangui/graphics/drawbuf.d
+++ b/src/dlangui/graphics/drawbuf.d
@@ -289,7 +289,7 @@ class DrawBuf : RefCountedObject {
     /// fill rectangle with solid color (clipping is applied)
     abstract void fillRect(Rect rc, uint color);
     /// fill rectangle with a gradient (clipping is applied)
-    abstract void fillGradientRect(Rect rc, uint color1, uint color2);
+    abstract void fillGradientRect(Rect rc, uint color1, uint color2, uint color3, uint color4);
     /// fill rectangle with solid color and pattern (clipping is applied) 0=solid fill, 1 = dotted
     void fillRectPattern(Rect rc, uint color, int pattern) {
         // default implementation: does not support patterns
@@ -1163,7 +1163,7 @@ class ColorDrawBufBase : DrawBuf {
         }
     }
 
-    override void fillGradientRect(Rect rc, uint color1, uint color2) {
+    override void fillGradientRect(Rect rc, uint color1, uint color2, uint color3, uint color4) {
         // TODO
         fillRect(rc, color1);
     }
@@ -1413,7 +1413,7 @@ class GrayDrawBuf : DrawBuf {
         }
     }
 
-    override void fillGradientRect(Rect rc, uint color1, uint color2) {
+    override void fillGradientRect(Rect rc, uint color1, uint color2, uint color3, uint color4) {
         // TODO
         fillRect(rc, color1);
     }

--- a/src/dlangui/graphics/drawbuf.d
+++ b/src/dlangui/graphics/drawbuf.d
@@ -288,6 +288,8 @@ class DrawBuf : RefCountedObject {
     abstract void fill(uint color);
     /// fill rectangle with solid color (clipping is applied)
     abstract void fillRect(Rect rc, uint color);
+    /// fill rectangle with a gradient (clipping is applied)
+    abstract void fillGradientRect(Rect rc, uint color1, uint color2);
     /// fill rectangle with solid color and pattern (clipping is applied) 0=solid fill, 1 = dotted
     void fillRectPattern(Rect rc, uint color, int pattern) {
         // default implementation: does not support patterns
@@ -1161,6 +1163,11 @@ class ColorDrawBufBase : DrawBuf {
         }
     }
 
+    override void fillGradientRect(Rect rc, uint color1, uint color2) {
+        // TODO
+        fillRect(rc, color1);
+    }
+
     /// fill rectangle with solid color and pattern (clipping is applied) 0=solid fill, 1 = dotted
     override void fillRectPattern(Rect rc, uint color, int pattern) {
         uint alpha = color >> 24;
@@ -1404,6 +1411,11 @@ class GrayDrawBuf : DrawBuf {
                 }
             }
         }
+    }
+
+    override void fillGradientRect(Rect rc, uint color1, uint color2) {
+        // TODO
+        fillRect(rc, color1);
     }
 
     /// draw pixel at (x, y) with specified color

--- a/src/dlangui/graphics/gldrawbuf.d
+++ b/src/dlangui/graphics/gldrawbuf.d
@@ -114,6 +114,15 @@ class GLDrawBuf : DrawBuf, GLConfigCallback {
             _scene.add(new SolidRectSceneItem(rc, color));
     }
 
+    /// fill rectangle with a gradient (clipping is applied)
+    override void fillGradientRect(Rect rc, uint color1, uint color2) {
+        assert(_scene !is null);
+        color1 = applyAlpha(color1);
+        color2 = applyAlpha(color2);
+        if (!(isFullyTransparentColor(color1) && isFullyTransparentColor(color2)) && applyClipping(rc))
+            _scene.add(new GradientRectSceneItem(rc, color1, color2));
+    }
+
     /// fill rectangle with solid color and pattern (clipping is applied) 0=solid fill, 1 = dotted
     override void fillRectPattern(Rect rc, uint color, int pattern) {
         if (pattern == PatternType.solid)
@@ -746,6 +755,23 @@ public:
     }
     override void draw() {
         glSupport.queue.addSolidRect(_rc, _color);
+    }
+}
+
+private class GradientRectSceneItem : SceneItem {
+private:
+    Rect _rc;
+    uint _color1;
+    uint _color2;
+
+public:
+    this(Rect rc, uint color1, uint color2) {
+        _rc = rc;
+        _color1 = color1;
+        _color2 = color2;
+    }
+    override void draw() {
+        glSupport.queue.addGradientRect(_rc, _color1, _color2, _color1, _color2);
     }
 }
 

--- a/src/dlangui/graphics/gldrawbuf.d
+++ b/src/dlangui/graphics/gldrawbuf.d
@@ -115,12 +115,14 @@ class GLDrawBuf : DrawBuf, GLConfigCallback {
     }
 
     /// fill rectangle with a gradient (clipping is applied)
-    override void fillGradientRect(Rect rc, uint color1, uint color2) {
+    override void fillGradientRect(Rect rc, uint color1, uint color2, uint color3, uint color4) {
         assert(_scene !is null);
         color1 = applyAlpha(color1);
         color2 = applyAlpha(color2);
-        if (!(isFullyTransparentColor(color1) && isFullyTransparentColor(color2)) && applyClipping(rc))
-            _scene.add(new GradientRectSceneItem(rc, color1, color2));
+        color3 = applyAlpha(color3);
+        color4 = applyAlpha(color4);
+        if (!(isFullyTransparentColor(color1) && isFullyTransparentColor(color3)) && applyClipping(rc))
+            _scene.add(new GradientRectSceneItem(rc, color1, color2, color3, color4));
     }
 
     /// fill rectangle with solid color and pattern (clipping is applied) 0=solid fill, 1 = dotted
@@ -763,15 +765,19 @@ private:
     Rect _rc;
     uint _color1;
     uint _color2;
+    uint _color3;
+    uint _color4;
 
 public:
-    this(Rect rc, uint color1, uint color2) {
+    this(Rect rc, uint color1, uint color2, uint color3, uint color4) {
         _rc = rc;
         _color1 = color1;
         _color2 = color2;
+        _color3 = color3;
+        _color4 = color4;
     }
     override void draw() {
-        glSupport.queue.addGradientRect(_rc, _color1, _color2, _color1, _color2);
+        glSupport.queue.addGradientRect(_rc, _color1, _color2, _color3, _color4);
     }
 }
 

--- a/src/dlangui/graphics/resources.d
+++ b/src/dlangui/graphics/resources.d
@@ -337,7 +337,7 @@ class GradientDrawable : Drawable {
         _color2 = color2;
     }
     override void drawTo(DrawBuf buf, Rect rc, uint state = 0, int tilex0 = 0, int tiley0 = 0) {
-        buf.fillRect(rc, _color1); // stub
+        buf.fillGradientRect(rc, _color1, _color2);
     }
     @property override int width() { return 1; }
     @property override int height() { return 1; }

--- a/src/dlangui/platforms/console/consoleapp.d
+++ b/src/dlangui/platforms/console/consoleapp.d
@@ -406,6 +406,11 @@ class ConsoleDrawBuf : DrawBuf {
         }
     }
 
+    override void fillGradientRect(Rect rc, uint color1, uint color2) {
+        // TODO
+        fillRect(rc, color1);
+    }
+
     /// fill rectangle with solid color and pattern (clipping is applied) 0=solid fill, 1 = dotted
     override void fillRectPattern(Rect rc, uint color, int pattern) {
         // default implementation: does not support patterns

--- a/src/dlangui/platforms/console/consoleapp.d
+++ b/src/dlangui/platforms/console/consoleapp.d
@@ -406,7 +406,7 @@ class ConsoleDrawBuf : DrawBuf {
         }
     }
 
-    override void fillGradientRect(Rect rc, uint color1, uint color2) {
+    override void fillGradientRect(Rect rc, uint color1, uint color2, uint color3, uint color4) {
         // TODO
         fillRect(rc, color1);
     }


### PR DESCRIPTION
Hello. I made an initial support for linear gradients.

Example:
```xml
<style id="MAIN_MENU"
    backgroundImageId="#linear,30deg,#bdf,#fff"
/>
```
Format is `#linear,angle,color1,color2`.

Result:

![screenshot from 2017-10-12](https://user-images.githubusercontent.com/16253876/31475885-fe98ca9a-af0b-11e7-923f-acfafa4153b8.png)

Works only on OpenGL build for now. I will try to implement this for software rasterizer too.