### PR TITLE
Add class hint for x11 window

### DIFF
--- a/src/dlangui/platforms/x11/x11app.d
+++ b/src/dlangui/platforms/x11/x11app.d
@@ -339,6 +339,14 @@ class X11Window : DWindow {
         XSetWMProtocols(x11display, _win, &atom_WM_DELETE_WINDOW, 1);
         _windowState = WindowState.hidden;
 
+        auto classHint = XAllocClassHint();
+        if (classHint) {
+            classHint.res_name = platform._classname;
+            classHint.res_class = platform._classname;
+            XSetClassHint(x11display, _win, classHint);
+            XFree(classHint);
+        }
+
         _children.reserve(20);
         _parent = cast(X11Window) parent;
         if (_parent)
@@ -1277,9 +1285,13 @@ private immutable int TIMER_EVENT = 8;
 class X11Platform : Platform {
 
     this() {
+        import std.file : thisExePath;
+        import std.path : baseName;
+        _classname = (baseName(thisExePath()) ~ "\0").dup.ptr;
     }
 
     private X11Window[XWindow] _windowMap;
+    private char* _classname;
 
     /**
      * create window


### PR DESCRIPTION
Some desktop environments (e.g. gnome) show name hint in taskbar and "Unknown" if it's not set.