### PR TITLE
Box shadows

### DIFF
--- a/src/dlangui/graphics/drawbuf.d
+++ b/src/dlangui/graphics/drawbuf.d
@@ -840,6 +840,11 @@ class DrawBuf : RefCountedObject {
         }
     }
 
+    /// Apply Gaussian blur on the image
+    void blur(uint blurSize) {
+        // TODO
+    }
+
     /// create drawbuf with copy of current buffer with changed colors (returns this if not supported)
     DrawBuf transformColors(ref ColorTransform transform) {
         return this;
@@ -858,20 +863,26 @@ class DrawBuf : RefCountedObject {
 
 alias DrawBufRef = Ref!DrawBuf;
 
-/// RAII setting/restoring of clip rectangle
+/// RAII setting/restoring of a DrawBuf clip rectangle
 struct ClipRectSaver {
     private DrawBuf _buf;
     private Rect _oldClipRect;
     private uint _oldAlpha;
-    /// apply (intersect) new clip rectangle and alpha to draw buf; restore
-    this(DrawBuf buf, ref Rect newClipRect, uint newAlpha = 0) {
+
+    /// apply (intersect) new clip rectangle and alpha to draw buf
+    /// set `intersect` parameter to `false`, if you want to draw something outside of the widget
+    this(DrawBuf buf, ref Rect newClipRect, uint newAlpha = 0, bool intersect = true) {
         _buf = buf;
         _oldClipRect = buf.clipRect;
         _oldAlpha = buf.alpha;
-        buf.intersectClipRect(newClipRect);
+        if (intersect)
+            buf.intersectClipRect(newClipRect);
+        else
+            buf.clipRect = newClipRect;
         if (newAlpha)
             buf.addAlpha(newAlpha);
     }
+    /// restore previous clip rectangle
     ~this() {
         _buf.clipRect = _oldClipRect;
         _buf.alpha = _oldAlpha;

--- a/src/dlangui/graphics/resources.d
+++ b/src/dlangui/graphics/resources.d
@@ -1136,7 +1136,7 @@ class CombinedDrawable : Drawable {
     DrawableRef background;
     DrawableRef border;
 
-    this(uint backgroundColor, string backgroundImageId, string borderDescription) {
+    this(uint backgroundColor, string backgroundImageId, string borderDescription, string boxShadowDescription) {
         background = 
             (backgroundImageId !is null) ? drawableCache.get(backgroundImageId) : 
             (!backgroundColor.isFullyTransparentColor) ? new SolidFillDrawable(backgroundColor) : null;

--- a/src/dlangui/widgets/styles.d
+++ b/src/dlangui/widgets/styles.d
@@ -324,6 +324,7 @@ protected:
     uint _alpha;
     string _fontFace;
     string _backgroundImageId;
+    string _boxShadow;
     string _border;
     Rect _padding;
     Rect _margins;
@@ -413,8 +414,10 @@ public:
             return (cast(Style)this)._backgroundDrawable;
         string image = backgroundImageId;
         uint color = backgroundColor;
-        if (border !is null) {
-            (cast(Style)this)._backgroundDrawable = new CombinedDrawable(color, image, border);
+        string borders = border;
+        string shadows = boxShadow;
+        if (borders !is null || shadows !is null) {
+            (cast(Style)this)._backgroundDrawable = new CombinedDrawable(color, image, borders, shadows);
         } else if (image !is null) {
             (cast(Style)this)._backgroundDrawable = drawableCache.get(image);
         } else {
@@ -528,6 +531,15 @@ public:
             return toPixels(_fontSize);
         } else
             return parentStyle.fontSize;
+    }
+
+    /// box shadow
+    @property string boxShadow() const {
+        if (_boxShadow !is null)
+            return _boxShadow;
+        else {
+            return parentStyle.boxShadow;
+        }
     }
 
     /// border
@@ -791,6 +803,12 @@ public:
         return this;
     }
 
+    @property Style boxShadow(string s) {
+        _boxShadow = s;
+        _backgroundDrawable.clear();
+        return this;
+    }
+
     @property Style border(string s) {
         _border = s;
         _backgroundDrawable.clear();
@@ -1037,6 +1055,10 @@ class Theme : Style {
     /// font size
     @property override string backgroundImageId() const {
         return _backgroundImageId;
+    }
+    /// box shadow
+    @property override string boxShadow() const {
+        return _boxShadow;
     }
     /// border
     @property override string border() const {
@@ -1527,6 +1549,11 @@ string sanitizeBorderProperty(string s) pure {
     return cast(string)res;
 }
 
+/// remove superfluous space characters from a box shadow property
+string sanitizeBoxShadowProperty(string s) pure {
+    return sanitizeBorderProperty(s);
+}
+
 /// load style attributes from XML element
 bool loadStyleAttributes(Style style, Element elem, bool allowStates) {
     //Log.d("Theme: loadStyleAttributes ", style.id, " ", elem.tag.attr);
@@ -1542,6 +1569,8 @@ bool loadStyleAttributes(Style style, Element elem, bool allowStates) {
         style.padding = decodeRect(elem.tag.attr["padding"]);
     if ("border" in elem.tag.attr)
         style.border = sanitizeBorderProperty(elem.tag.attr["border"]);
+    if ("boxShadow" in elem.tag.attr)
+        style.boxShadow = sanitizeBoxShadowProperty(elem.tag.attr["boxShadow"]);
     if ("align" in elem.tag.attr)
         style.alignment = decodeAlignment(elem.tag.attr["align"]);
     if ("minWidth" in elem.tag.attr)

--- a/src/dlangui/widgets/styles.d
+++ b/src/dlangui/widgets/styles.d
@@ -926,6 +926,7 @@ public:
         res._alpha = _alpha;
         res._fontFace = _fontFace;
         res._backgroundImageId = _backgroundImageId;
+        res._boxShadow = _boxShadow;
         res._border = _border;
         res._padding = _padding;
         res._margins = _margins;


### PR DESCRIPTION
Like with borders, added the `boxShadow` property and the `BoxShadowDrawable` class. Shadows can be blurred, but for now they are rectangular only.

Examples:
```xml
<style id="EDIT_LINE"
    border="#aaa,1"
    backgroundColor="#fff"
    >
    <state state_enabled="true" state_focused="true" border="#2040ff,1" boxShadow="0, 0, 3, #d52040ff" />
</style>

<style id="FLOATING_WINDOW"
    border="#555,1"
    backgroundColor="#fff"
    boxShadow="0,4,8,#aa000000"
/>
```
![screenshot from 2017-10-14 1](https://user-images.githubusercontent.com/16253876/31605563-331ae26a-b26f-11e7-92ce-bc92e8e551ca.png)
![screenshot from 2017-10-14](https://user-images.githubusercontent.com/16253876/31605565-34579858-b26f-11e7-917f-f5447ea38c69.png)
