### PR TITLE
Added FILE_DIALOG_GRID along with backgroundImageId to theme.

### DIFF
--- a/views/res/theme_dark.xml
+++ b/views/res/theme_dark.xml
@@ -235,6 +235,9 @@
     <style id="STRING_GRID"
         backgroundImageId="editbox_background_dark"
         />
+    <style id="FILE_DIALOG_GRID"
+        backgroundImageId="editbox_background_dark"
+        />
     <style id="DOCK_HOST"
         backgroundColor="#515658"
         />


### PR DESCRIPTION
Else "editbox_background_dark" is not loaded (or overridden by editbox_background), when dark theme is used.