### PR TITLE
Fixes for TextWidget/MultilineTextWidget

### DIFF
--- a/src/dlangui/widgets/controls.d
+++ b/src/dlangui/widgets/controls.d
@@ -115,7 +115,7 @@ class TextWidget : Widget {
         return this;
     }
 
-    private CalcSaver!(Font, dstring, uint, uint) _measureSaver;
+    private CalcSaver!(Font, dstring, uint, uint, int) _measureSaver;
 
     override void measure(int parentWidth, int parentHeight) {
         FontRef font = font();
@@ -131,7 +131,7 @@ class TextWidget : Widget {
         uint flags = textFlags;
 
         // optimization: do not measure if nothing changed
-        if (_measureSaver.check(font.get, text, w, flags) || _needLayout) {
+        if (_measureSaver.check(font.get, text, w, flags, maxLines) || _needLayout) {
             Point sz;
             if (maxLines == 1) {
                 sz = font.textSize(text, w, 4, 0, flags);

--- a/src/dlangui/widgets/controls.d
+++ b/src/dlangui/widgets/controls.d
@@ -119,8 +119,15 @@ class TextWidget : Widget {
 
     override void measure(int parentWidth, int parentHeight) {
         FontRef font = font();
-        uint w = (maxLines == 1) ? MAX_WIDTH_UNSPECIFIED :
-                                   parentWidth - margins.left - margins.right - padding.left - padding.right;
+        
+        uint w;
+        if (maxLines == 1) 
+            w = MAX_WIDTH_UNSPECIFIED;
+        else {
+            w = parentWidth - margins.left - margins.right - padding.left - padding.right;
+            if (maxWidth > 0 && maxWidth < w)
+                w = maxWidth - padding.left - padding.right;
+        }
         uint flags = textFlags;
 
         // optimization: do not measure if nothing changed


### PR DESCRIPTION
- fix multi line when `maxWidth` is set.
- `_measureSaver` should check `maxLines` changes