### PR TITLE
Word Wrapping Implementation

### DIFF
--- a/src/dlangui/core/editable.d
+++ b/src/dlangui/core/editable.d
@@ -455,18 +455,24 @@ struct LineSpan {
     /// the wrapped text
     dstring[] wrappedContent;
     
-    int widthAccumulation(int wrapLine)
+    enum WrapPointInfo : bool {
+        Position,
+        Width,
+    }
+    
+    int accumulation(int wrapLine, bool wrapPointInfo)
     {
-        int widthTotal;
+        int total;
         for (int i; i < wrapLine; i++)
         {
             if (i < this.wrapPoints.length - 1)
             {
-                int curWidth = this.wrapPoints[i].wrapWidth;
-                widthTotal += curWidth;
+                int curVal;
+                curVal = wrapPointInfo ? this.wrapPoints[i].wrapWidth : this.wrapPoints[i].wrapPos;
+                total += curVal;
             }
         }
-        return widthTotal;
+        return total;
     }
 }
 

--- a/src/dlangui/core/editable.d
+++ b/src/dlangui/core/editable.d
@@ -460,6 +460,7 @@ struct LineSpan {
         Width,
     }
     
+    ///Adds up either positions or widths to a wrapLine
     int accumulation(int wrapLine, bool wrapPointInfo)
     {
         int total;
@@ -476,8 +477,11 @@ struct LineSpan {
     }
 }
 
+///Holds info about a word wrapping point
 struct WrapPoint {
+    ///The relative wrapping position (related to TextPosition.pos)
     int wrapPos;
+    ///The associated calculated width of the wrapLine
     int wrapWidth;
 }
 

--- a/src/dlangui/core/editable.d
+++ b/src/dlangui/core/editable.d
@@ -450,6 +450,15 @@ struct LineSpan {
     int start;
     /// number of lines it spans
     int len;
+    /// the wrapping points
+    WrapPoint[] wrapPoints;
+    
+    dstring[] wrappedContent;
+}
+
+struct WrapPoint {
+    int wrapPos;
+    int wrapWidth;
 }
 
 /// interface for custom syntax highlight, comments toggling, smart indents, and other language dependent features for source code editors

--- a/src/dlangui/core/editable.d
+++ b/src/dlangui/core/editable.d
@@ -452,8 +452,22 @@ struct LineSpan {
     int len;
     /// the wrapping points
     WrapPoint[] wrapPoints;
-    
+    /// the wrapped text
     dstring[] wrappedContent;
+    
+    int widthAccumulation(int wrapLine)
+    {
+        int widthTotal;
+        for (int i; i < wrapLine; i++)
+        {
+            if (i < this.wrapPoints.length - 1)
+            {
+                int curWidth = this.wrapPoints[i].wrapWidth;
+                widthTotal += curWidth;
+            }
+        }
+        return widthTotal;
+    }
 }
 
 struct WrapPoint {

--- a/src/dlangui/widgets/editors.d
+++ b/src/dlangui/widgets/editors.d
@@ -3731,6 +3731,7 @@ class EditBox : EditWidgetBase {
         }
 
         FontRef font = font();
+        int previousWraps;
         for (int i = 0; i < _visibleLines.length; i++) {
             dstring txt = _visibleLines[i];
             Rect lineRect;
@@ -3747,7 +3748,16 @@ class EditBox : EditWidgetBase {
             if (!txt.length && !_wordWrap)
                 continue;
             if (_showWhiteSpaceMarks)
-                drawWhiteSpaceMarks(buf, font, txt, tabSize, lineRect, visibleRect);
+            {
+                Rect whiteSpaceRc = lineRect;
+                Rect whiteSpaceRcVisible = visibleRect;
+                for(int z; z < previousWraps; z++)
+                {
+                    whiteSpaceRc.offset(0, _lineHeight);
+                    whiteSpaceRcVisible.offset(0, _lineHeight);
+                }
+                drawWhiteSpaceMarks(buf, font, txt, tabSize, whiteSpaceRc, whiteSpaceRcVisible);
+            }
             if (_leftPaneWidth > 0) {
                 Rect leftPaneRect = visibleRect;
                 leftPaneRect.right = leftPaneRect.left;
@@ -3779,6 +3789,7 @@ class EditBox : EditWidgetBase {
                             font.drawText(buf, rc.left - _scrollPos.x, rc.top + lineOffset * _lineHeight, curWrap, textColor, tabSize);
 
                     }
+                    previousWraps += to!int(wrappedLine.length - 1);
                 }
                 else
                 {

--- a/src/dlangui/widgets/editors.d
+++ b/src/dlangui/widgets/editors.d
@@ -1290,8 +1290,6 @@ class EditWidgetBase : ScrollWidgetBase, EditableContentListener, MenuItemAction
             handleAction(ACTION_EDITOR_SELECT_ALL);
         super.handleFocusChange(focused);
     }
-    
-    protected int _firstVisibleLine;
 
     //In word wrap mode, set by caretRect so ensureCaretVisible will know when to scroll
     protected int caretHeightOffset;
@@ -2553,7 +2551,7 @@ class EditBox : EditWidgetBase {
         }
     }
 
-    //protected int _firstVisibleLine;
+    protected int _firstVisibleLine;
 
     protected int _maxLineWidth;
     protected int _numVisibleLines;             // number of lines visible in client area

--- a/src/dlangui/widgets/editors.d
+++ b/src/dlangui/widgets/editors.d
@@ -3320,8 +3320,28 @@ class EditBox : EditWidgetBase {
             if (lineRect.top >= _clientRect.bottom)
                 break;
             drawLeftPane(buf, lineRect, i < lc ? i : -1);
-            i++;
             rc.top += _lineHeight;
+            if (_wordWrap)
+            {
+                int currentWrap = 1;
+                for (;;)
+                {
+                    LineSpan curSpan = getSpan(i);
+                    if (currentWrap > curSpan.len - 1)
+                        break;
+                    Rect lineRect2 = rc;
+                    lineRect2.left = _clientRect.left - _leftPaneWidth;
+                    lineRect2.right = _clientRect.left;
+                    lineRect2.bottom = lineRect.top + _lineHeight;
+                    if (lineRect2.top >= _clientRect.bottom)
+                        break;
+                    drawLeftPane(buf, lineRect2, -1);
+                    rc.top += _lineHeight;
+
+                    currentWrap++;
+                }
+            }
+            i++;
         }
     }
 

--- a/src/dlangui/widgets/editors.d
+++ b/src/dlangui/widgets/editors.d
@@ -3451,7 +3451,7 @@ class EditBox : EditWidgetBase {
         _span = [];
     }
     
-    private bool needRewrap;
+    private bool needRewrap = true;
     private int lastStartingLine;
     
     override protected void drawClient(DrawBuf buf) {

--- a/src/dlangui/widgets/editors.d
+++ b/src/dlangui/widgets/editors.d
@@ -520,7 +520,7 @@ class EditWidgetBase : ScrollWidgetBase, EditableContentListener, MenuItemAction
     
     LineSpan getSpan(int lineNumber)
     {
-        LineSpan lineSpan = LineSpan(lineNumber, 0, [], []);
+        LineSpan lineSpan = LineSpan(lineNumber, 0, [WrapPoint(0,0)], []);
         lineSpanIterate(delegate(LineSpan curSpan)
         {
             if (curSpan.start == lineNumber)
@@ -1291,7 +1291,7 @@ class EditWidgetBase : ScrollWidgetBase, EditableContentListener, MenuItemAction
                 LineSpan curSpan = getSpan(_caretPos.line);
                 xOffset = curSpan.widthAccumulation(wrapLine);
             }
-            auto yOffset = -1 * _lineHeight * (wrapsUpTo(_caretPos.line - _firstVisibleLine) + wrapLine);
+            auto yOffset = -1 * _lineHeight * (wrapsUpTo(_caretPos.line) + wrapLine);
             caretRc.offset(_clientRect.left - xOffset, _clientRect.top - yOffset);
         }
         else

--- a/src/dlangui/widgets/editors.d
+++ b/src/dlangui/widgets/editors.d
@@ -1289,7 +1289,7 @@ class EditWidgetBase : ScrollWidgetBase, EditableContentListener, MenuItemAction
             if (wrapLine > 0)
             {
                 LineSpan curSpan = getSpan(_caretPos.line);
-                xOffset = curSpan.widthAccumulation(wrapLine);
+                xOffset = curSpan.accumulation(wrapLine, LineSpan.WrapPointInfo.Width);
             }
             auto yOffset = -1 * _lineHeight * (wrapsUpTo(_caretPos.line) + wrapLine);
             caretRc.offset(_clientRect.left - xOffset, _clientRect.top - yOffset);

--- a/src/dlangui/widgets/editors.d
+++ b/src/dlangui/widgets/editors.d
@@ -518,6 +518,36 @@ class EditWidgetBase : ScrollWidgetBase, EditableContentListener, MenuItemAction
         return sum;
     }
     
+    LineSpan getSpan(int lineNumber)
+    {
+        LineSpan lineSpan = LineSpan(lineNumber, 0, [], []);
+        lineSpanIterate(delegate(LineSpan curSpan)
+        {
+            if (curSpan.start == lineNumber)
+                lineSpan = curSpan;
+        });
+        return lineSpan;
+    }
+    
+    int findWrapLine(TextPosition textPos)
+    {
+        int curLine = 0;
+        int curPosition = textPos.pos;
+        int i = 0;
+        while (true)
+        {
+            if (i == getSpan(textPos.line).wrapPoints.length - 1)
+                return curLine;
+            curPosition -= getSpan(textPos.line).wrapPoints[i].wrapPos;
+            if (curPosition < 0)
+            {   
+                return curLine;
+            }
+            curLine++;
+            i++;
+        }
+    }
+    
     void lineSpanIterate(void delegate(LineSpan curSpan) iterator)
     {
         foreach (currentSpan; _span)
@@ -1249,7 +1279,13 @@ class EditWidgetBase : ScrollWidgetBase, EditableContentListener, MenuItemAction
                 caretRc.right += _spaceWidth;
             }
         }
-        caretRc.offset(_clientRect.left, _clientRect.top);
+        if (_wordWrap)
+            {
+                _scrollPos.x = 0;
+                caretRc.offset(_clientRect.left, _clientRect.top);
+            }
+        else
+            caretRc.offset(_clientRect.left, _clientRect.top);
         return caretRc;
     }
 

--- a/src/dlangui/widgets/editors.d
+++ b/src/dlangui/widgets/editors.d
@@ -2771,7 +2771,8 @@ class EditBox : EditWidgetBase {
             invalidate();
         } else if (rc.left >= _clientRect.width - 10) {
             // scroll right
-            _scrollPos.x += (rc.left - _clientRect.width) + _clientRect.width / 4;
+            if (!_wordWrap)
+                _scrollPos.x += (rc.left - _clientRect.width) + _clientRect.width / 4;
             invalidate();
         }
         updateScrollBars();

--- a/src/dlangui/widgets/editors.d
+++ b/src/dlangui/widgets/editors.d
@@ -1264,6 +1264,8 @@ class EditWidgetBase : ScrollWidgetBase, EditableContentListener, MenuItemAction
             handleAction(ACTION_EDITOR_SELECT_ALL);
         super.handleFocusChange(focused);
     }
+    
+    protected int _firstVisibleLine;
 
     /// returns cursor rectangle
     protected Rect caretRect() {
@@ -1280,10 +1282,18 @@ class EditWidgetBase : ScrollWidgetBase, EditableContentListener, MenuItemAction
             }
         }
         if (_wordWrap)
+        {
+            _scrollPos.x = 0;
+            int wrapLine = findWrapLine(_caretPos);
+            int xOffset;
+            if (wrapLine > 0)
             {
-                _scrollPos.x = 0;
-                caretRc.offset(_clientRect.left, _clientRect.top);
+                LineSpan curSpan = getSpan(_caretPos.line);
+                xOffset = curSpan.widthAccumulation(wrapLine);
             }
+            auto yOffset = -1 * _lineHeight * (wrapsUpTo(_caretPos.line - _firstVisibleLine) + wrapLine);
+            caretRc.offset(_clientRect.left - xOffset, _clientRect.top - yOffset);
+        }
         else
             caretRc.offset(_clientRect.left, _clientRect.top);
         return caretRc;
@@ -2470,7 +2480,7 @@ class EditBox : EditWidgetBase {
         }
     }
 
-    protected int _firstVisibleLine;
+    //protected int _firstVisibleLine;
 
     protected int _maxLineWidth;
     protected int _numVisibleLines;             // number of lines visible in client area

--- a/src/dlangui/widgets/editors.d
+++ b/src/dlangui/widgets/editors.d
@@ -531,20 +531,18 @@ class EditWidgetBase : ScrollWidgetBase, EditableContentListener, MenuItemAction
     
     int findWrapLine(TextPosition textPos)
     {
-        int curLine = 0;
+        int curWrapLine = 0;
         int curPosition = textPos.pos;
-        int i = 0;
         while (true)
         {
-            if (i == getSpan(textPos.line).wrapPoints.length - 1)
-                return curLine;
-            curPosition -= getSpan(textPos.line).wrapPoints[i].wrapPos;
+            if (curWrapLine == getSpan(textPos.line).wrapPoints.length - 1)
+                return curWrapLine;
+            curPosition -= getSpan(textPos.line).wrapPoints[curWrapLine].wrapPos;
             if (curPosition < 0)
             {   
-                return curLine;
+                return curWrapLine;
             }
-            curLine++;
-            i++;
+            curWrapLine++;
         }
     }
     

--- a/src/dlangui/widgets/editors.d
+++ b/src/dlangui/widgets/editors.d
@@ -3468,6 +3468,12 @@ class EditBox : EditWidgetBase {
         if (_contentChanged)
           needRewrap = true;
           
+        if (lastStartingLine != _firstVisibleLine)
+        {
+            needRewrap = true;
+            lastStartingLine = _firstVisibleLine;
+        }
+          
         if (rc.width <= 0 && _wordWrap)
         {
             return;
@@ -3520,7 +3526,7 @@ class EditBox : EditWidgetBase {
                     CustomCharProps[] wrapProps;
                     foreach (int q, curWrap; wrappedLine)
                     {
-                        auto lineOffset = q + i + wrapsUpTo(i);
+                        auto lineOffset = q + i + wrapsUpTo(i + _firstVisibleLine);
                         if (highlight)
                         {
                             wrapProps = highlight[accumulativeLength .. $];

--- a/src/dlangui/widgets/editors.d
+++ b/src/dlangui/widgets/editors.d
@@ -3317,24 +3317,29 @@ class EditBox : EditWidgetBase {
         rc.right = _clientRect.left + endrc.right;
         if (_wordWrap && !rc.empty)
         {
-            auto limitNumber = (int num, int limit) => num > limit ? limit : num;
-            LineSpan curSpan = getSpan(r.start.line);
-            int yOffset = _lineHeight * (wrapsUpTo(r.start.line));
-            rc.offset(0, yOffset);
-            Rect[] wrappedSelection;
-            wrappedSelection.length = curSpan.len;
-            foreach (int i, wrapLineRect; wrappedSelection)
-            {
-                wrapLineRect = rc;
-                wrapLineRect.offset(-1 * curSpan.accumulation(i, LineSpan.WrapPointInfo.Width), i * _lineHeight);
-                wrapLineRect.right = limitNumber(wrapLineRect.right,(rc.left + curSpan.wrapPoints[i].wrapWidth));
-                //buf.fillRect(wrapLineRect, focused ? _selectionColorFocused : _selectionColorNormal);
-                buf.fillRect(wrapLineRect, color);
-            }
+            wordWrapFillRect(buf, r.start.line, rc, color);
         }
         else if (!rc.empty) {
             // draw selection rect for matching bracket
             buf.fillRect(rc, color);
+        }
+    }
+    
+    void wordWrapFillRect(DrawBuf buf, int line, Rect lineToDivide, uint color)
+    {
+        Rect rc = lineToDivide;
+        auto limitNumber = (int num, int limit) => num > limit ? limit : num;
+        LineSpan curSpan = getSpan(line);
+        int yOffset = _lineHeight * (wrapsUpTo(line));
+        rc.offset(0, yOffset);
+        Rect[] wrappedSelection;
+        wrappedSelection.length = curSpan.len;
+        foreach (int i, wrapLineRect; wrappedSelection)
+        {
+            wrapLineRect = rc;
+            wrapLineRect.offset(-1 * curSpan.accumulation(i, LineSpan.WrapPointInfo.Width), i * _lineHeight);
+            wrapLineRect.right = limitNumber(wrapLineRect.right,(rc.left + curSpan.wrapPoints[i].wrapWidth));
+            buf.fillRect(wrapLineRect, color);
         }
     }
 
@@ -3355,19 +3360,7 @@ class EditBox : EditWidgetBase {
             rc.right = endx;
             if (!rc.empty && _wordWrap)
             {
-                auto limitNumber = (int num, int limit) => num > limit ? limit : num;
-                LineSpan curSpan = getSpan(lineIndex);
-                int yOffset = _lineHeight * (wrapsUpTo(lineIndex));
-                rc.offset(0, yOffset);
-                Rect[] wrappedSelection;
-                wrappedSelection.length = curSpan.len;
-                foreach (int i, wrapLineRect; wrappedSelection)
-                {
-                    wrapLineRect = rc;
-                    wrapLineRect.offset(-1 * curSpan.accumulation(i, LineSpan.WrapPointInfo.Width), i * _lineHeight);
-                    wrapLineRect.right = limitNumber(wrapLineRect.right,(rc.left + curSpan.wrapPoints[i].wrapWidth));
-                    buf.fillRect(wrapLineRect, focused ? _selectionColorFocused : _selectionColorNormal);
-                }
+                wordWrapFillRect(buf, lineIndex, rc, focused ? _selectionColorFocused : _selectionColorNormal);
             }
             else if (!rc.empty) {
                 // draw selection rect for line

--- a/src/dlangui/widgets/editors.d
+++ b/src/dlangui/widgets/editors.d
@@ -510,35 +510,18 @@ class EditWidgetBase : ScrollWidgetBase, EditableContentListener, MenuItemAction
     int wrapsUpTo(int line)
     {
         int sum;
-        lineSpanIterate(delegate(int wantedLine, int wantedWrap)
+        lineSpanIterate(delegate(LineSpan curSpan)
         {
-            if (wantedLine < line)
-                sum += _span[wantedLine].len - 1;
+            if (curSpan.start < line)
+                sum += curSpan.len - 1;
         });
         return sum;
-        /*if(line < _span.length)
-        {
-            
-            int sum;
-            for(int i = 0; i<line; i++)
-            {
-                sum += _span[i].len - 1;
-            }
-            //Log.d(sum);
-            return sum;
-        }*/
-        //return 0;
     }
     
-    void lineSpanIterate(void delegate(int wantedLine, int wantedWrap) iterator)
+    void lineSpanIterate(void delegate(LineSpan curSpan) iterator)
     {
-        for (int i; i<_span.length; i++)
-        {
-            for (int q; q<_span[i].wrapPoints.length; q++)
-            {
-                iterator(i, q);
-            }
-        }
+        foreach (currentSpan; _span)
+            iterator(currentSpan);
     }
 
     /// override to add custom items on left panel

--- a/src/dlangui/widgets/editors.d
+++ b/src/dlangui/widgets/editors.d
@@ -474,6 +474,7 @@ class EditWidgetBase : ScrollWidgetBase, EditableContentListener, MenuItemAction
     
     /// information about line span into several lines - in word wrap mode
     protected LineSpan[] _span;
+    protected LineSpan[] _spanCache;
     
     //Finds good visual wrapping point for string
     int findWrapPoint(dstring text)
@@ -508,7 +509,14 @@ class EditWidgetBase : ScrollWidgetBase, EditableContentListener, MenuItemAction
     
     int wrapsUpTo(int line)
     {
-        if(line < _span.length)
+        int sum;
+        lineSpanIterate(delegate(int wantedLine, int wantedWrap)
+        {
+            if (wantedLine < line)
+                sum += _span[wantedLine].len - 1;
+        });
+        return sum;
+        /*if(line < _span.length)
         {
             
             int sum;
@@ -518,8 +526,19 @@ class EditWidgetBase : ScrollWidgetBase, EditableContentListener, MenuItemAction
             }
             //Log.d(sum);
             return sum;
+        }*/
+        //return 0;
+    }
+    
+    void lineSpanIterate(void delegate(int wantedLine, int wantedWrap) iterator)
+    {
+        for (int i; i<_span.length; i++)
+        {
+            for (int q; q<_span[i].wrapPoints.length; q++)
+            {
+                iterator(i, q);
+            }
         }
-        return 0;
     }
 
     /// override to add custom items on left panel

--- a/src/dlangui/widgets/editors.d
+++ b/src/dlangui/widgets/editors.d
@@ -3315,7 +3315,24 @@ class EditBox : EditWidgetBase {
         Rect rc = lineRect;
         rc.left = _clientRect.left + startrc.left;
         rc.right = _clientRect.left + endrc.right;
-        if (!rc.empty) {
+        if (_wordWrap && !rc.empty)
+        {
+            auto limitNumber = (int num, int limit) => num > limit ? limit : num;
+            LineSpan curSpan = getSpan(r.start.line);
+            int yOffset = _lineHeight * (wrapsUpTo(r.start.line));
+            rc.offset(0, yOffset);
+            Rect[] wrappedSelection;
+            wrappedSelection.length = curSpan.len;
+            foreach (int i, wrapLineRect; wrappedSelection)
+            {
+                wrapLineRect = rc;
+                wrapLineRect.offset(-1 * curSpan.accumulation(i, LineSpan.WrapPointInfo.Width), i * _lineHeight);
+                wrapLineRect.right = limitNumber(wrapLineRect.right,(rc.left + curSpan.wrapPoints[i].wrapWidth));
+                //buf.fillRect(wrapLineRect, focused ? _selectionColorFocused : _selectionColorNormal);
+                buf.fillRect(wrapLineRect, color);
+            }
+        }
+        else if (!rc.empty) {
             // draw selection rect for matching bracket
             buf.fillRect(rc, color);
         }

--- a/src/dlangui/widgets/editors.d
+++ b/src/dlangui/widgets/editors.d
@@ -1266,6 +1266,7 @@ class EditWidgetBase : ScrollWidgetBase, EditableContentListener, MenuItemAction
     
     protected int _firstVisibleLine;
 
+    protected int caretHeightOffset;
     /// returns cursor rectangle
     protected Rect caretRect() {
         Rect caretRc = textPosToClient(_caretPos);
@@ -1291,6 +1292,7 @@ class EditWidgetBase : ScrollWidgetBase, EditableContentListener, MenuItemAction
                 xOffset = curSpan.accumulation(wrapLine, LineSpan.WrapPointInfo.Width);
             }
             auto yOffset = -1 * _lineHeight * (wrapsUpTo(_caretPos.line) + wrapLine);
+            caretHeightOffset = yOffset;
             caretRc.offset(_clientRect.left - xOffset, _clientRect.top - yOffset);
         }
         else
@@ -2743,6 +2745,22 @@ class EditBox : EditWidgetBase {
                 _firstVisibleLine = maxFirstVisibleLine;
             measureVisibleText();
             invalidate();
+        } else if(_wordWrap && !(_firstVisibleLine > maxFirstVisibleLine)) {
+            //For wordwrap mode, move down sooner
+            int offsetLines = -1 * caretHeightOffset / _lineHeight;
+            //Log.d("offsetLines: ", offsetLines);
+            if (_caretPos.line >= _firstVisibleLine + visibleLines - offsetLines)
+            {
+                _firstVisibleLine = _caretPos.line - visibleLines + 1 + offsetLines;
+                if (center)
+                    _firstVisibleLine += visibleLines / 2;
+                if (_firstVisibleLine > maxFirstVisibleLine)
+                    _firstVisibleLine = maxFirstVisibleLine;
+                if (_firstVisibleLine < 0)
+                    _firstVisibleLine = 0;
+                measureVisibleText();
+                invalidate();
+            }
         } else if (_caretPos.line >= _firstVisibleLine + visibleLines) {
             _firstVisibleLine = _caretPos.line - visibleLines + 1;
             if (center)

--- a/src/dlangui/widgets/editors.d
+++ b/src/dlangui/widgets/editors.d
@@ -3336,7 +3336,23 @@ class EditBox : EditWidgetBase {
             Rect rc = lineRect;
             rc.left = startx;
             rc.right = endx;
-            if (!rc.empty) {
+            if (!rc.empty && _wordWrap)
+            {
+                auto limitNumber = (int num, int limit) => num > limit ? limit : num;
+                LineSpan curSpan = getSpan(lineIndex);
+                int yOffset = _lineHeight * (wrapsUpTo(lineIndex));
+                rc.offset(0, yOffset);
+                Rect[] wrappedSelection;
+                wrappedSelection.length = curSpan.len;
+                foreach (int i, wrapLineRect; wrappedSelection)
+                {
+                    wrapLineRect = rc;
+                    wrapLineRect.offset(-1 * curSpan.accumulation(i, LineSpan.WrapPointInfo.Width), i * _lineHeight);
+                    wrapLineRect.right = limitNumber(wrapLineRect.right,(rc.left + curSpan.wrapPoints[i].wrapWidth));
+                    buf.fillRect(wrapLineRect, focused ? _selectionColorFocused : _selectionColorNormal);
+                }
+            }
+            else if (!rc.empty) {
                 // draw selection rect for line
                 buf.fillRect(rc, focused ? _selectionColorFocused : _selectionColorNormal);
             }

--- a/src/dlangui/widgets/editors.d
+++ b/src/dlangui/widgets/editors.d
@@ -533,11 +533,12 @@ class EditWidgetBase : ScrollWidgetBase, EditableContentListener, MenuItemAction
     {
         int curWrapLine = 0;
         int curPosition = textPos.pos;
+        LineSpan curSpan = getSpan(textPos.line);
         while (true)
         {
-            if (curWrapLine == getSpan(textPos.line).wrapPoints.length - 1)
+            if (curWrapLine == curSpan.wrapPoints.length - 1)
                 return curWrapLine;
-            curPosition -= getSpan(textPos.line).wrapPoints[curWrapLine].wrapPos;
+            curPosition -= curSpan.wrapPoints[curWrapLine].wrapPos;
             if (curPosition < 0)
             {   
                 return curWrapLine;


### PR DESCRIPTION
This is my implementation for word wrapping. It should be complete as far as I know. There are still certain things which could be optimized or refactored some but I am not sure what would match best with dlangui's coding style.

Notes:

1. The basic algorithm itself (methods wrapLine and explode) is based on this C# one from user IRC https://stackoverflow.com/questions/17586/best-word-wrap-algorithm
I have changed it a lot though translating it to D so I think it should be fair use.

2. Word wrap mode works by drawing everything for EditBox at a offset.
3. Another than the word wrapping function itself, I use the term "wrapLine" to describe any divided part of a line in word wrap mode. A line which is not wrapped is / has one wrapLine.
4. The WrapPoint struct is for describing the end of wrapLines in relative position and drawn width.
5. _span contains the info for each line in word wrap.
6. The measureWrappedText function might be kind of redundant, it just calls measureText.
7. At the moment, the box around the wrapLine with the caret is a little slow following when moving between wrapLines.
8. Sometimes, if toggling between word wrap and normal, the horizontal scrollbar will get drawn over with text. This is probably an easy thing to fix.

Edit: Also the branch is called "wordwrap2"  since I rewrote a lot of my previous wordwrap branch to simplify it. There is still probably more that can be done to make it simpler.