### PR TITLE
Ability to change min size edit text.

### DIFF
--- a/src/dlangui/widgets/editors.d
+++ b/src/dlangui/widgets/editors.d
@@ -2314,6 +2314,16 @@ class EditLine : EditWidgetBase {
 
     protected Point _measuredTextToSetWidgetSize;
     protected dstring _textToSetWidgetSize = "aaaaa"d;
+    
+    @property void textToSetWidgetSize(dstring newText) {
+        _textToSetWidgetSize = newText;
+        requestLayout();
+    }
+
+    @property dstring textToSetWidgetSize() {
+        return _textToSetWidgetSize;
+    }
+    
     protected int[] _measuredTextToSetWidgetSizeWidths;
 
     protected dchar _passwordChar = 0;


### PR DESCRIPTION
Min size of `EditLine` is based on `_textToSetWidgetSize`. This PR gives ability to set it.