### PR TITLE
Possibility to override cursor type for entire window.

### DIFF
--- a/src/dlangui/platforms/common/platform.d
+++ b/src/dlangui/platforms/common/platform.d
@@ -1111,6 +1111,20 @@ class Window : CustomEventTarget {
         return res;
     }
 
+    /// Keep overrided cursor type or NotSet to get cursor from widget
+    protected CursorType _overrideCursorType = CursorType.NotSet;
+
+    /// Allow override cursor for entire window. Set to CursorType.NotSet to remove cursor type overriding.
+    @property void overrideCursorType(CursorType newCursorType) {
+        _overrideCursorType = newCursorType;
+        setCursorType(newCursorType);
+    }
+
+    /// Returns current window override cursor type or NotSet if not overriding.
+    @property CursorType overrideCursorType() {
+        return _overrideCursorType;
+    }
+    
     protected bool dispatchMouseEvent(Widget root, MouseEvent event, ref bool cursorIsSet) {
         // only route mouse events to visible widgets
         if (root.visibility != Visibility.Visible)
@@ -1123,9 +1137,10 @@ class Window : CustomEventTarget {
             if (dispatchMouseEvent(child, event, cursorIsSet))
                 return true;
         }
+
         if (event.action == MouseAction.Move && !cursorIsSet) {
             uint cursorType = root.getCursorType(event.x, event.y);
-            if (cursorType != CursorType.Parent) {
+            if (cursorType != CursorType.NotSet) {
                 setCursorType(cursorType);
                 cursorIsSet = true;
             }
@@ -1463,11 +1478,17 @@ class Window : CustomEventTarget {
             }
             return res;
         }
+
         bool processed = false;
         if (event.action == MouseAction.Move || event.action == MouseAction.Leave) {
             processed = checkRemoveTracking(event);
         }
+        
         bool cursorIsSet = false;
+        if (overrideCursorType != CursorType.NotSet) {
+            cursorIsSet = true;
+        }
+        
         if (!res) {
             bool insideOneOfPopups = false;
             for (int i = cast(int)_popups.length - 1; i >= 0; i--) {

--- a/src/dlangui/platforms/windows/winapp.d
+++ b/src/dlangui/platforms/windows/winapp.d
@@ -680,7 +680,7 @@ class Win32Window : Window {
             case None:
                 winCursor = null;
                 break;
-            case Parent:
+            case NotSet:
                 break;
             case Arrow:
                 winCursor = loadCursor(IDC_ARROW);

--- a/src/dlangui/platforms/x11/x11app.d
+++ b/src/dlangui/platforms/x11/x11app.d
@@ -1962,7 +1962,7 @@ extern(C) int DLANGUImain(string[] args)
     setupX11Atoms();
 
     x11cursors[CursorType.None] = XCreateFontCursor(x11display, XC_arrow);
-    x11cursors[CursorType.Parent] = XCreateFontCursor(x11display, XC_arrow);
+    x11cursors[CursorType.NotSet] = XCreateFontCursor(x11display, XC_arrow);
     x11cursors[CursorType.Arrow] = XCreateFontCursor(x11display, XC_left_ptr);
     x11cursors[CursorType.IBeam] = XCreateFontCursor(x11display, XC_xterm);
     x11cursors[CursorType.Wait] = XCreateFontCursor(x11display, XC_watch);

--- a/src/dlangui/widgets/widget.d
+++ b/src/dlangui/widgets/widget.d
@@ -132,8 +132,8 @@ enum FocusMovement {
 /// standard mouse cursor types
 enum CursorType {
     None,
-    /// use parent's cursor
-    Parent,
+    /// When set in widget means to use parent's cursor, in Window.overrideCursorType() disable overriding.
+    NotSet,
     Arrow,
     IBeam,
     Wait,


### PR DESCRIPTION
Possibility to override cursor type for entire window by setting `Window.overrideCursorType`. For example:

`Window.overrideCursorType = CursorType.Wait`

Remove overriding:

`Window.overrideCursorType = CursorType.NotSet`

To not add extra value I changed `CursorType.Parent` to `CursorType.NotSet`.