### PR TITLE
Normalize end of line characters when get text from clipboard in SDL

### DIFF
--- a/src/dlangui/platforms/sdl/sdlapp.d
+++ b/src/dlangui/platforms/sdl/sdlapp.d
@@ -1489,7 +1489,7 @@ class SDLPlatform : Platform {
             return ""d;
         string s = fromStringz(txt).dup;
         SDL_free(txt);
-        return toUTF32(s);
+        return normalizeEndOfLineCharacters(toUTF32(s));
     }
 
     /// sets text to clipboard (when mouseBuffer == true, use mouse selection clipboard - under linux)


### PR DESCRIPTION
Without this there are squares in empty lines on Windows (SDL backend). I think it should be done on other systems too. 