### PR TITLE
assert before cached drawbuf modification

### DIFF
--- a/src/dlangui/graphics/gldrawbuf.d
+++ b/src/dlangui/graphics/gldrawbuf.d
@@ -175,8 +175,8 @@ class GLDrawBuf : DrawBuf, GLConfigCallback {
         assert(_scene !is null);
         //Log.v("GLDrawBuf.frawRescaled dst=", dstrect, " src=", srcrect);
         if (applyClipping(dstrect, srcrect)) {
-            if (!glImageCache.isInCache(src.id))
-                glImageCache.put(src);
+            assert(!glImageCache.isInCache(src.id));
+            glImageCache.put(src);
             _scene.add(new TextureSceneItem(src.id, dstrect, srcrect, applyAlpha(0xFFFFFF), 0, null));
         }
     }


### PR DESCRIPTION
Do not merge this PR!

I am faced with the fact that is after once usage of DrawBuf this buffer is cached and after that no matter how it changes: result of using this buffer is result of using of a previously cached buffer.

Every time replacing of this buffer after it changed seems not a very good idea in terms of performance. Therefore, I propose to change all changing GLDrawBuf functions by this way.