### PR TITLE
 Possibility to add popup menu to any widget, menu behavior fixes.

### DIFF
--- a/src/dlangui/platforms/common/platform.d
+++ b/src/dlangui/platforms/common/platform.d
@@ -1505,8 +1505,11 @@ class Window : CustomEventTarget {
                 if (p is modal)
                     break;
                 if (!insideOneOfPopups) {
-                    if (p.onMouseEventOutside(event)) // stop loop when true is returned, but allow other main widget to handle event
-                        break;
+                    if (event.action == MouseAction.ButtonDown)
+                        return true; // mouse button down should do nothing when click outside when popup visible
+                    if (p.onMouseEventOutside(event)) {
+                        return true; // mouse button up should do nothing when click outside when popup visible
+                    }
                 } else {
                     if (dispatchMouseEvent(p, event, cursorIsSet))
                         return true;

--- a/src/dlangui/widgets/appframe.d
+++ b/src/dlangui/widgets/appframe.d
@@ -256,7 +256,7 @@ class AppFrame : VerticalLayout, MenuItemClickHandler, MenuItemActionHandler {
     }
 
     /// override to handle main menu actions
-    bool onMenuItemAction(const Action action) {
+    override bool onMenuItemAction(const Action action) {
         // default handling: dispatch action using window (first offered to focused control, then to main widget)
         return window.dispatchAction(action);
     }

--- a/src/dlangui/widgets/editors.d
+++ b/src/dlangui/widgets/editors.d
@@ -849,13 +849,6 @@ class EditWidgetBase : ScrollWidgetBase, EditableContentListener, MenuItemAction
         acceleratorMap.add([ACTION_EDITOR_FIND_NEXT, ACTION_EDITOR_FIND_PREV]);
     }
 
-    protected MenuItem _popupMenu;
-    @property MenuItem popupMenu() { return _popupMenu; }
-    @property EditWidgetBase popupMenu(MenuItem popupMenu) {
-        _popupMenu = popupMenu;
-        return this;
-    }
-
     ///
     override bool onMenuItemAction(const Action action) {
         return dispatchAction(action);

--- a/src/dlangui/widgets/grid.d
+++ b/src/dlangui/widgets/grid.d
@@ -1005,7 +1005,7 @@ class GridWidgetBase : ScrollWidgetBase, GridModelAdapter, MenuItemActionHandler
     }
 
     /// handle popup menu action
-    protected bool onMenuItemAction(const Action action) {
+    protected override bool onMenuItemAction(const Action action) {
         if (menuItemAction.assigned)
             return menuItemAction(action);
         return false;

--- a/src/dlangui/widgets/menu.d
+++ b/src/dlangui/widgets/menu.d
@@ -937,7 +937,7 @@ class MainMenu : MenuWidgetBase {
         super(null, null, Orientation.Horizontal);
         id = "MAIN_MENU";
         styleId = STYLE_MAIN_MENU;
-        _clickOnButtonDown = true;
+        _clickOnButtonDown = false;
         selectOnHover = false;
     }
 
@@ -945,7 +945,7 @@ class MainMenu : MenuWidgetBase {
         super(null, item, Orientation.Horizontal);
         id = "MAIN_MENU";
         styleId = STYLE_MAIN_MENU;
-        _clickOnButtonDown = true;
+        _clickOnButtonDown = false;
         selectOnHover = false;
     }
 

--- a/src/dlangui/widgets/popup.d
+++ b/src/dlangui/widgets/popup.d
@@ -174,10 +174,10 @@ class PopupWidget : LinearLayout {
         if (visibility != Visibility.Visible)
             return false;
         if (_flags & PopupFlags.CloseOnClickOutside) {
-            if (event.action == MouseAction.ButtonDown) {
+            if (event.action == MouseAction.ButtonUp) {
                 // clicked outside - close popup
                 close();
-                return false;
+                return true;
             }
         }
         if (_flags & PopupFlags.CloseOnMouseMoveOutside) {


### PR DESCRIPTION
These changes allow you to add a popup menu to each Widget. For example I need to add menu to checkbox or label. 

In addition, I changed the way the menu works. Clicking outside the menu when it is open only closes it and does not forward the event to the control under the mouse cursor. Previous behavior caused frequent accidental changes when the user just tried to close the popup menu.

Tested in DlangIDE and my Agile Commander 1.1  (version not yet released).