### PR TITLE
Allow individually named DockHost

### DIFF
--- a/src/dlangui/widgets/docks.d
+++ b/src/dlangui/widgets/docks.d
@@ -205,7 +205,11 @@ class DockHost : WidgetGroupDefaultDrawing {
     }
 
     this() {
-        super("DOCK_HOST");
+        this("DOCK_HOST");
+    }
+
+    this(string ID) {
+        super(ID);
         styleId = STYLE_DOCK_HOST;
         addChild(_topSpace.initialize(this, DockAlignment.Top));
         addChild(_bottomSpace.initialize(this, DockAlignment.Bottom));


### PR DESCRIPTION
I don't see why not to allow multiple DockHost's.