### PR TITLE
(Tetris Example) Error: min is not defined, perhaps import std.algorithm; is needed?

### DIFF
--- a/examples/tetris/src/gui.d
+++ b/examples/tetris/src/gui.d
@@ -3,6 +3,7 @@ module gui;
 import model;
 
 import dlangui;
+import std.algorithm;
 
 /// game action codes
 enum TetrisAction : int {


### PR DESCRIPTION
It seems that Tetris example stopped working on the more newer versions of d lang.

After adding `import std.algorithm;` Tetris seems to work now.

### Error message before applying `import std.algorithm;` -
<pre><code>
vaidas@vaidas-SATELLITE-L855:~$ dub run dlangui:tetris
Building package dlangui:tetris in /home/vaidas/.dub/packages/dlangui-0.9.182/dlangui/examples/tetris/
Performing "debug" build using dmd for x86_64.
derelict-util 3.0.0-beta.2: target for configuration "library" is up to date.
derelict-ft 2.0.0-beta.5: target for configuration "library" is up to date.
derelict-gl3 2.0.0-beta.8: target for configuration "library" is up to date.
derelict-sdl2 3.0.0-beta.8: target for configuration "derelict-sdl2-dynamic" is up to date.
dlangui 0.9.182: target for configuration "minimal" is up to date.
dlangui:tetris 0.9.182: building configuration "application"...
<b>.dub/packages/dlangui-0.9.182/dlangui/examples/tetris/src/gui.d(562,20): Error: min is not defined, perhaps import std.algorithm; is needed?</b>
dmd failed with exit code 1.
</code></pre>


### Me, after applying `import std.algorithm;` - happily playing Tetris on my Linux machine:
![Screenshot from 2019-09-18 17-47-46](https://user-images.githubusercontent.com/21064622/65159301-883b6e80-da3c-11e9-81aa-18a5750249eb.png)


