### PR TITLE
TTC(truetype collection) file extention and OEM charset face name on Windows

### DIFF
--- a/src/dlangui/core/settings.d
+++ b/src/dlangui/core/settings.d
@@ -498,7 +498,7 @@ final class Setting {
             case UINTEGER:
                 return to!string(_store.uinteger);
             case FLOAT:
-                return to!string(_store.floating);
+                return to!string(cast(double)_store.floating);
             case TRUE:
                 return "true";
             case FALSE:
@@ -519,7 +519,7 @@ final class Setting {
             case UINTEGER:
                 return to!string(_store.uinteger);
             case FLOAT:
-                return to!string(_store.floating);
+                return to!string(cast(double)_store.floating);
             case TRUE:
                 return "true";
             case FALSE:

--- a/src/dlangui/graphics/fonts.d
+++ b/src/dlangui/graphics/fonts.d
@@ -239,6 +239,8 @@ class Font : RefCountedObject {
         bool fixed = isFixed;
         bool useKerning = allowKerning && !fixed;
         int fixedCharWidth = charWidth('M');
+        if (fixedCharWidth == 0)
+            fixedCharWidth = spaceWidth;
         int x = 0;
         int charsMeasured = 0;
         int * pwidths = widths.ptr;

--- a/src/dlangui/graphics/ftfonts.d
+++ b/src/dlangui/graphics/ftfonts.d
@@ -771,7 +771,9 @@ bool registerFontConfigFonts(FreeTypeFontManager fontMan) {
         }
         string fn = fromStringz(s).dup;
         string fn16 = toLower(fn);
-        if (!fn16.endsWith(".ttf") && !fn16.endsWith(".odf") && !fn16.endsWith(".otf") && !fn16.endsWith(".pfb") && !fn16.endsWith(".pfa")  ) {
+        if (!fn16.endsWith(".ttf") && !fn16.endsWith(".odf") && !fn16.endsWith(".otf") &&
+            !fn16.endsWith(".ttc") && !fn16.endsWith(".pfb") && !fn16.endsWith(".pfa")  )
+        {
             continue;
         }
         int weight = FC_WEIGHT_MEDIUM;
@@ -912,9 +914,6 @@ bool registerFontConfigFonts(FreeTypeFontManager fontMan) {
         }
 
         */
-        facesFound++;
-
-
     }
 
     FcFontSetDestroy(fontset);

--- a/src/dlangui/platforms/windows/win32fonts.d
+++ b/src/dlangui/platforms/windows/win32fonts.d
@@ -30,6 +30,7 @@ import dlangui.graphics.fonts;
 import dlangui.platforms.windows.win32drawbuf;
 import std.string;
 import std.utf;
+import std.windows.charset;
 
 /// define debug=FontResources for logging of font file resources creation/freeing
 //debug = FontResources;
@@ -446,9 +447,13 @@ class Win32Font : Font {
         if (!isNull())
             clear();
         LOGFONTA lf;
-        lf.lfCharSet = ANSI_CHARSET; //DEFAULT_CHARSET;
-        lf.lfFaceName[0..def.face.length] = def.face;
-        lf.lfFaceName[def.face.length] = 0;
+        // OEM charset face name
+        lf.lfCharSet = DEFAULT_CHARSET; //ANSI_CHARSET;
+        // lf.lfFaceName[0..def.face.length] = def.face;
+        // lf.lfFaceName[def.face.length] = 0;
+        string oemFace = fromStringz(toMBSz(def.face)).dup;
+        lf.lfFaceName[0..oemFace.length] = oemFace;
+        lf.lfFaceName[oemFace.length] = 0;
         lf.lfHeight = -size; //pixelsToPoints(size);
         lf.lfItalic = italic;
         lf.lfWeight = weight;
@@ -545,7 +550,7 @@ class Win32FontManager : FontManager {
         debug Log.i("Win32FontManager.initialize()");
         Win32ColorDrawBuf drawbuf = new Win32ColorDrawBuf(1,1);
         LOGFONTA lf;
-        lf.lfCharSet = ANSI_CHARSET; //DEFAULT_CHARSET;
+        lf.lfCharSet = DEFAULT_CHARSET; //ANSI_CHARSET;
         lf.lfFaceName[0] = 0;
         HDC dc = drawbuf.dc;
         int res =
@@ -705,7 +710,9 @@ extern(Windows) {
         {
             void * p = cast(void*)lParam;
             Win32FontManager fontman = cast(Win32FontManager)p;
-            string face = fromStringz(lf.lfFaceName.ptr).dup;
+            // OEM charset face name
+            // string face = fromStringz(lf.lfFaceName.ptr).dup;
+            string face = fromMBSz(cast(immutable)lf.lfFaceName.ptr).dup;
             FontFamily family = pitchAndFamilyToFontFamily(lf.lfPitchAndFamily);
             if (face.length < 2 || face[0] == '@')
                 return 1;


### PR DESCRIPTION
I tried to list all fonts but I met following problems.

1.Linux - some fonts are missing because of file extention check.
2. Windows - I met exception during code conversion.

Please review my patches.
Here is my linux and windows screenshot.

Screen Shot
-----------------

### Linux

![2002-07-15](https://seoyoungjin.github.com/screenshot/dfontview/20200715.png)

### Windows

Face name with current locale - OEM charset

![2002-07-16](https://seoyoungjin.github.com/screenshot/dfontview/20200716_gungseo_win.png)

I'm a beginner to D, so I might make a ridiculous mistake, so please take good care of me.