### PR TITLE
Migrate to bindbc

### DIFF
--- a/3rdparty/dimage/png.d
+++ b/3rdparty/dimage/png.d
@@ -582,7 +582,7 @@ in
 {
     assert (img.data.length);
 }
-body
+do
 {
     Compound!(bool, string) error(string errorMsg)
     {

--- a/3rdparty/fontconfig/functions.d
+++ b/3rdparty/fontconfig/functions.d
@@ -5,48 +5,48 @@ public import fontconfig.fctypes;
 
 extern( C ) @nogc nothrow {
 
-    alias da_FC_FcObjectSetBuild = FcObjectSet * function(const char *first, ...);
+    alias pFcObjectSetBuild = FcObjectSet * function(const char *first, ...);
 
-    alias da_FC_FcPatternCreate = FcPattern * function();
+    alias pFcPatternCreate = FcPattern * function();
 
-    alias da_FC_FcPatternAddBool = FcBool function(FcPattern *p, const char *object, FcBool b);
+    alias pFcPatternAddBool = FcBool function(FcPattern *p, const char *object, FcBool b);
 
-    alias da_FC_FcFontList = FcFontSet * function(FcConfig    *config, FcPattern    *p, FcObjectSet *os);
+    alias pFcFontList = FcFontSet * function(FcConfig    *config, FcPattern    *p, FcObjectSet *os);
 
-    alias da_FC_FcPatternDestroy = void function(FcPattern *p);
+    alias pFcPatternDestroy = void function(FcPattern *p);
 
-    alias da_FC_FcObjectSetDestroy = void function(FcObjectSet *os);
+    alias pFcObjectSetDestroy = void function(FcObjectSet *os);
 
-    alias da_FC_FcPatternGetString = FcResult function(const FcPattern *p, const char *object, int n, FcChar8 ** s);
+    alias pFcPatternGetString = FcResult function(const FcPattern *p, const char *object, int n, FcChar8 ** s);
 
-    alias da_FC_FcPatternGetInteger = FcResult function(const FcPattern *p, const char *object, int n, int *i);
+    alias pFcPatternGetInteger = FcResult function(const FcPattern *p, const char *object, int n, int *i);
 
-    alias da_FC_FcPatternGetBool = FcResult function(const FcPattern *p, const char *object, int n, FcBool *b);
+    alias pFcPatternGetBool = FcResult function(const FcPattern *p, const char *object, int n, FcBool *b);
 
-    alias da_FC_FcFontSetDestroy = void  function(FcFontSet *s);
+    alias pFcFontSetDestroy = void  function(FcFontSet *s);
 }
 
 __gshared {
 
-    da_FC_FcObjectSetBuild FcObjectSetBuild;
+    pFcObjectSetBuild FcObjectSetBuild;
 
-    da_FC_FcPatternCreate FcPatternCreate;
+    pFcPatternCreate FcPatternCreate;
 
-    da_FC_FcPatternAddBool FcPatternAddBool;
+    pFcPatternAddBool FcPatternAddBool;
 
-    da_FC_FcFontList FcFontList;
+    pFcFontList FcFontList;
 
-    da_FC_FcPatternDestroy FcPatternDestroy;
+    pFcPatternDestroy FcPatternDestroy;
 
-    da_FC_FcObjectSetDestroy FcObjectSetDestroy;
+    pFcObjectSetDestroy FcObjectSetDestroy;
 
-    da_FC_FcPatternGetString FcPatternGetString;
+    pFcPatternGetString FcPatternGetString;
 
-    da_FC_FcPatternGetInteger FcPatternGetInteger;
+    pFcPatternGetInteger FcPatternGetInteger;
 
-    da_FC_FcPatternGetBool FcPatternGetBool;
+    pFcPatternGetBool FcPatternGetBool;
 
-    da_FC_FcFontSetDestroy FcFontSetDestroy;
+    pFcFontSetDestroy FcFontSetDestroy;
 }
 
 /+

--- a/3rdparty/fontconfig/package.d
+++ b/3rdparty/fontconfig/package.d
@@ -3,42 +3,88 @@ module fontconfig;
 public import fontconfig.fctypes;
 public import fontconfig.functions;
 
+import bindbc.loader;
+
+enum FCSupport {
+    noLibrary,
+    badLibrary,
+    // TODO: real versions and stuff
+    fc100      = 100,
+}
+
 private {
-    import derelict.util.loader;
-    import derelict.util.system;
-
-    static if( Derelict_OS_Windows )
-        enum libNames = "libfontconfig-1.dll";
-    else static if( Derelict_OS_Mac )
-        enum libNames = "/usr/local/lib/libfontconfig.dylib";
-    else static if( Derelict_OS_Posix )
-        enum libNames = "libfontconfig.so.1, libfontconfig.so";
-    else
-        static assert( 0, "Need to implement FontConfig libNames for this operating system." );
+    SharedLib lib;
+    FCSupport loadedVersion;
 }
 
 
-class DerelictFCLoader : SharedLibLoader {
-      public this() {
-            super( libNames );
-      }
-
-      protected override void loadSymbols() {
-            bindFunc( cast( void** )&FcObjectSetBuild, "FcObjectSetBuild" );
-            bindFunc( cast( void** )&FcPatternCreate, "FcPatternCreate" );
-            bindFunc( cast( void** )&FcPatternAddBool, "FcPatternAddBool" );
-            bindFunc( cast( void** )&FcFontList, "FcFontList" );
-            bindFunc( cast( void** )&FcPatternDestroy, "FcPatternDestroy" );
-            bindFunc( cast( void** )&FcObjectSetDestroy, "FcObjectSetDestroy" );
-            bindFunc( cast( void** )&FcPatternGetString, "FcPatternGetString" );
-            bindFunc( cast( void** )&FcPatternGetInteger, "FcPatternGetInteger" );
-            bindFunc( cast( void** )&FcPatternGetBool, "FcPatternGetBool" );
-            bindFunc( cast( void** )&FcFontSetDestroy, "FcFontSetDestroy" );
-      }
+@nogc nothrow:
+void unloadFC()
+{
+    if(lib != invalidHandle) {
+        lib.unload();
+    }
 }
 
-__gshared DerelictFCLoader DerelictFC;
 
-shared static this() {
-    DerelictFC = new DerelictFCLoader();
+FCSupport loadedFCVersion() { return loadedVersion; }
+
+bool isFCLoaded()
+{
+    return  lib != invalidHandle;
+}
+
+
+FCSupport loadFC()
+{
+    // #1778 prevents from using static arrays here :(
+    version(Windows) {
+        const(char)[][1] libNames = [ "libfontconfig-1.dll"];
+    }
+    else version(OSX) {
+        const(char)[][1] libNames = [
+            "/usr/local/lib/libfontconfig.dylib"
+        ];
+    }
+    else version(Posix) {
+        const(char)[][2] libNames = [
+            "libfontconfig.so.1", 
+            "libfontconfig.so"
+        ];
+    }
+    else static assert(0, "bindbc-fc is not yet supported on this platform.");
+
+    FCSupport ret;
+    foreach(name; libNames) {
+        ret = loadFC(name.ptr);
+        if(ret != FCSupport.noLibrary) break;
+    }
+    return ret;
+}
+
+FCSupport loadFC(const(char)* libName)
+{
+    lib = load(libName);
+    if(lib == invalidHandle) {
+        return FCSupport.noLibrary;
+    }
+
+    auto errCount = errorCount();
+    loadedVersion = FCSupport.badLibrary;
+
+    lib.bindSymbol( cast( void** )&FcObjectSetBuild, "FcObjectSetBuild" );
+    lib.bindSymbol( cast( void** )&FcPatternCreate, "FcPatternCreate" );
+    lib.bindSymbol( cast( void** )&FcPatternAddBool, "FcPatternAddBool" );
+    lib.bindSymbol( cast( void** )&FcFontList, "FcFontList" );
+    lib.bindSymbol( cast( void** )&FcPatternDestroy, "FcPatternDestroy" );
+    lib.bindSymbol( cast( void** )&FcObjectSetDestroy, "FcObjectSetDestroy" );
+    lib.bindSymbol( cast( void** )&FcPatternGetString, "FcPatternGetString" );
+    lib.bindSymbol( cast( void** )&FcPatternGetInteger, "FcPatternGetInteger" );
+    lib.bindSymbol( cast( void** )&FcPatternGetBool, "FcPatternGetBool" );
+    lib.bindSymbol( cast( void** )&FcFontSetDestroy, "FcFontSetDestroy" );
+
+    if(errorCount() != errCount) return FCSupport.badLibrary;
+    else loadedVersion = FCSupport.fc100;
+
+    return loadedVersion;
 }

--- a/dub.json
+++ b/dub.json
@@ -30,11 +30,8 @@
     "excludedSourceFiles-windows": ["3rdparty/fontconfig/*"],
 
     "dependencies": {
-        "bindbc-opengl": "~>1.0.0",
         "inilike": "~>1.2.1"
     },
-
-    "versions": ["GL_AllowDeprecated", "GL_30"],
 
     "subPackages": [
         "./examples/helloworld/",
@@ -52,16 +49,17 @@
     "configurations": [
         {
             "name": "default",
-            "versions": ["USE_OPENGL", "EmbedStandardResources"],
-            "versions-posix": ["USE_SDL", "USE_FREETYPE"],
+            "versions": ["USE_OPENGL", "EmbedStandardResources", "GL_32"],
+            "versions-posix": ["USE_SDL", "USE_FREETYPE", "SDL_204"],
             "versions-windows": ["Unicode"],
             "libs-windows": ["opengl32"],
             "dependencies": {
-                "derelict-ft": "~>2.0.0-beta.5",
-                "icontheme": "~>1.2.3"
+                "bindbc-opengl": "~>1.0.0",
+                "bindbc-freetype": "~>1.0.0"
             },
             "dependencies-posix": {
-                "derelict-sdl2": "~>3.0.0-beta.8"
+                "bindbc-sdl": "~>1.0.0",
+                "icontheme": "~>1.2.3"
             },
             "copyFiles-windows-x86_64": [
                 "libs/windows/x86_64/libfreetype-6.dll"
@@ -73,6 +71,7 @@
         {
             "name": "console",
             "versions": ["USE_CONSOLE", "EmbedStandardResources"],
+            "libs-windows": ["user32"],
             "excludedSourceFiles": ["3rdparty/*GL*", "3rdparty/android", "3rdparty/dimage", "3rdparty/fontconfig/*", "3rdparty/icontheme", "3rdparty/jni.d"]
         },
         {
@@ -80,8 +79,8 @@
             "versions": ["USE_EXTERNAL"],
             "libs-windows": ["opengl32"],
             "dependencies": {
-                "derelict-ft": "~>2.0.0-beta.5",
-                "icontheme": "~>1.2.3"
+                "bindbc-opengl": "~>1.0.0",
+                "bindbc-freetype": "~>1.0.0"
             }
         },
         {
@@ -91,18 +90,21 @@
             "versions-windows": ["Unicode" ,"NO_OPENGL"],
             "libs-windows": ["opengl32"],
             "dependencies-posix": {
-                "derelict-sdl2": "~>3.0.0-beta.8",
-                "derelict-ft": "~>2.0.0-beta.5",
-                "icontheme": "~>1.2.3"
+                "bindbc-opengl": "~>1.0.0",
+                "bindbc-freetype": "~>1.0.0",
+                "bindbc-sdl": "~>1.0.0"
             }
         },
         {
             "name": "sdl",
-            "versions": ["USE_SDL", "USE_OPENGL", "USE_FREETYPE", "EmbedStandardResources"],
+            "versions": ["USE_SDL", "USE_OPENGL", "USE_FREETYPE", "EmbedStandardResources", "GL_32", "SDL_204"],
             "versions-windows": ["Unicode"],
             "dependencies": {
-                "derelict-ft": "~>2.0.0-beta.5",
-                "derelict-sdl2": "~>3.0.0-beta.8",
+                "bindbc-opengl": "~>1.0.0",
+                "bindbc-freetype": "~>1.0.0",
+                "bindbc-sdl": "~>1.0.0"
+            },
+            "dependencies-posix": {
                 "icontheme": "~>1.2.3"
             },
             "copyFiles-windows-x86_64": [
@@ -116,20 +118,22 @@
         },
         {
             "name": "x11",
-            "versions": ["USE_X11", "USE_FREETYPE", "EmbedStandardResources"],
+            "versions": ["USE_X11", "USE_FREETYPE", "EmbedStandardResources", "GL_32"],
             "versions-windows": ["Unicode"],
             "dependencies": {
-                "derelict-ft": "~>2.0.0-beta.5",
+                "bindbc-opengl": "~>1.0.0",
+                "bindbc-freetype": "~>1.0.0",
                 "x11": "~>1.0.21",
                 "icontheme": "~>1.2.3"
             }
         },
         {
             "name": "sfml",
-            "versions": ["USE_DSFML", "USE_OPENGL", "USE_FREETYPE", "EmbedStandardResources"],
+            "versions": ["USE_DSFML", "USE_OPENGL", "USE_FREETYPE", "EmbedStandardResources", "GL_32"],
             "versions-windows": ["Unicode"],
             "dependencies": {
-                "derelict-ft": "~>2.0.0-beta.4",
+                "bindbc-opengl": "~>1.0.0",
+                "bindbc-freetype": "~>1.0.0",
                 "dsfml": "~>2.1.0",
                 "icontheme": "~>1.2.3"
             },

--- a/examples/d3d/src/d3d.d
+++ b/examples/d3d/src/d3d.d
@@ -13,7 +13,7 @@ import dlangui.graphics.scene.objimport;
 import dlangui.graphics.scene.fbximport;
 import dlangui.graphics.glsupport;
 import dlangui.graphics.gldrawbuf;
-import derelict.opengl.gl;
+import bindbc.opengl;
 
 mixin APP_ENTRY_POINT;
 

--- a/examples/dminer/dub.json
+++ b/examples/dminer/dub.json
@@ -11,6 +11,8 @@
     "targetName": "dminer",
     "targetType": "executable",
 
+    "sourceFiles-windows-x86": ["$PACKAGE_DIR/src/win_app.def"],
+
     "versions": ["EmbedStandardResources"],
 
     "dependencies": {

--- a/examples/example1/src/example1.d
+++ b/examples/example1/src/example1.d
@@ -1283,8 +1283,7 @@ void main()
 
 static if (ENABLE_OPENGL) {
 
-    import derelict.opengl; //3.gl3;
-    //import derelict.opengl3.gl;
+    import bindbc.opengl;
 
     class MyOpenglWidget : VerticalLayout {
         this() {

--- a/examples/opengl/dub.json
+++ b/examples/opengl/dub.json
@@ -11,7 +11,7 @@
 
     "stringImportPaths": ["views", "views/res", "views/res/i18n", "views/res/mdpi"],
 
-    "versions": ["EmbedStandardResources"],
+    "versions": ["EmbedStandardResources", "GL_AllowDeprecated"],
 
     "dependencies": {
         "dlangui": {"path": "../../"}

--- a/examples/opengl/src/openglexample.d
+++ b/examples/opengl/src/openglexample.d
@@ -33,6 +33,7 @@ extern (C) int UIAppMain(string[] args) {
 
 static if (ENABLE_OPENGL):
 
+import bindbc.opengl;
 import dlangui.graphics.glsupport;
 import dlangui.graphics.gldrawbuf;
 
@@ -134,7 +135,7 @@ class MyOpenglWidget : VerticalLayout {
             return;
         }
         bool canUseOldApi = !!glLightfv;
-        bool canUseNewApi = !glSupport.legacyMode;
+        bool canUseNewApi = true;
         if (_exampleIndex == 0 || !canUseOldApi)
             drawUsingNewAPI(windowRect, rc);
         else if (_exampleIndex == 1 || !canUseNewApi)

--- a/src/dlangui/core/editable.d
+++ b/src/dlangui/core/editable.d
@@ -24,7 +24,7 @@ import dlangui.core.linestream;
 import dlangui.core.streams;
 import std.algorithm;
 import std.conv : to;
-import std.uni;
+static import std.uni;
 
 // uncomment FileFormats debug symbol to dump file formats for loaded/saved files.
 //debug = FileFormats;

--- a/src/dlangui/platforms/sdl/sdlapp.d
+++ b/src/dlangui/platforms/sdl/sdlapp.d
@@ -39,18 +39,18 @@ import dlangui.widgets.styles;
 import dlangui.widgets.widget;
 import dlangui.platforms.common.platform;
 
-import derelict.sdl2.sdl;
+import bindbc.sdl;
 
 static if (ENABLE_OPENGL) {
     import bindbc.opengl;
     import dlangui.graphics.gldrawbuf;
     import dlangui.graphics.glsupport;
+    import loader = bindbc.loader.sharedlib;
 }
 
-private derelict.util.exception.ShouldThrow missingSymFunc( string symName ) {
+private void sdlCheckMissingSymFunc(const(loader.ErrorInfo)[] errors) {
     import std.algorithm : equal;
-    static import derelict.util.exception;
-    foreach(s; ["SDL_DestroyRenderer", "SDL_GL_DeleteContext", "SDL_DestroyWindow", "SDL_PushEvent",
+    immutable names = ["SDL_DestroyRenderer", "SDL_GL_DeleteContext", "SDL_DestroyWindow", "SDL_PushEvent",
                 "SDL_GL_SetAttribute", "SDL_GL_CreateContext", "SDL_GetError",
                 "SDL_CreateWindow", "SDL_CreateRenderer", "SDL_GetWindowSize",
                 "SDL_GL_GetDrawableSize", "SDL_GetWindowID", "SDL_SetWindowSize",
@@ -63,12 +63,19 @@ private derelict.util.exception.ShouldThrow missingSymFunc( string symName ) {
                 "SDL_RemoveTimer", "SDL_RemoveTimer", "SDL_PushEvent",
                 "SDL_RegisterEvents", "SDL_WaitEvent", "SDL_StartTextInput",
                 "SDL_Quit", "SDL_HasClipboardText", "SDL_GetClipboardText",
-                "SDL_free", "SDL_SetClipboardText", "SDL_Init", "SDL_GetNumVideoDisplays"]) {//"SDL_GetDisplayDPI"
-        if (symName.equal(s)) // Symbol is used
-            return derelict.util.exception.ShouldThrow.Yes;
+                "SDL_free", "SDL_SetClipboardText", "SDL_Init", "SDL_GetNumVideoDisplays"]; //"SDL_GetDisplayDPI"
+    foreach(info; errors)
+    {
+        import std.array;
+        import std.algorithm;
+        import std.exception;
+        import core.stdc.string;
+        // NOTE: this has crappy complexity as it was just updated as is
+        //     it also does not checks if the symbol was actually loaded
+        auto errMsg = cast(string) info.message[0 .. info.message.strlen];
+        bool found = names.any!(s => s.indexOf(errMsg) != -1);
+        enforce(!found, { return errMsg.idup; });
     }
-    // Don't throw for unused symbol
-    return derelict.util.exception.ShouldThrow.No;
 }
 
 private __gshared SDL_EventType USER_EVENT_ID;
@@ -1638,9 +1645,12 @@ int sdlmain(string[] args) {
     }
 
     try {
-        DerelictSDL2.missingSymbolCallback = &missingSymFunc;
+        import std.exception;
+        //DerelictSDL2.missingSymbolCallback = &missingSymFunc;
         // Load the SDL 2 library.
-        DerelictSDL2.load();
+        auto sdlVer = loadSDL();
+        enforce(sdlVer != SDLSupport.noLibrary && sdlVer != SDLSupport.badLibrary, "bindbc-sdl unable to find SDL2 library");
+        sdlCheckMissingSymFunc(loader.errors);
     } catch (Exception e) {
         Log.e("Cannot load SDL2 library", e);
         return 1;

--- a/src/dlangui/platforms/windows/winapp.d
+++ b/src/dlangui/platforms/windows/winapp.d
@@ -151,7 +151,7 @@ static if (ENABLE_OPENGL) {
         return hPalette;
     }
 
-    private __gshared bool DERELICT_GL3_RELOADED = false;
+    private __gshared bool BINDBC_GL3_RELOADED = false; // is this even used?
 }
 
 const uint CUSTOM_MESSAGE_ID = WM_USER + 1;
@@ -323,6 +323,8 @@ class Win32Window : Window {
             EndPaint(_hwnd, &ps);
 
 
+            import bindbc.opengl; //3.gl3;
+            import bindbc.opengl; //3.wgl;
             import dlangui.graphics.gldrawbuf;
             //Log.d("onPaint() start drawing opengl viewport: ", _dx, "x", _dy);
             //PAINTSTRUCT ps;
@@ -1305,6 +1307,38 @@ string[] splitCmdLine(string line) {
 }
 
 private __gshared Win32Platform w32platform;
+
+static if (ENABLE_OPENGL) {
+    import bindbc.opengl;
+    import bindbc.opengl.config : GLSupportVersion = GLSupport;
+
+    void initOpenGL() {
+        try {
+            Log.d("Loading bindbc-opengl");
+            auto glVer = loadOpenGL();
+            if(glVer < GLSupportVersion.gl32) {
+                import std.format : format;
+                throw new Exception(format!"OpenGL 3.2 or higher is required, got: %s"(glVer));
+            }
+            Log.d("bindbc-opengl - loaded");
+            //
+            //// just to check OpenGL context
+            //Log.i("Trying to setup OpenGL context");
+            //Win32Window tmpWindow = new Win32Window(w32platform, ""d, null, 0);
+            //destroy(tmpWindow);
+            //if (openglEnabled)
+            //    Log.i("OpenGL support is enabled");
+            //else
+            //    Log.w("OpenGL support is disabled");
+            //// process messages
+            //platform.enterMessageLoop();
+        } catch (Exception e) {
+            Log.e("Exception while trying to init OpenGL", e);
+            setOpenglEnabled(false);
+        }
+    }
+}
+
 
 int myWinMain(void* hInstance, void* hPrevInstance, char* lpCmdLine, int iCmdShow)
 {


### PR DESCRIPTION
BindBC is a newer loader mechanism that replaces Derelict, as Derelict is now basically discontinued I've migrated dlangui to use bindbc instead.

**Note: provided .dll/.so needs to be updated as well, otherwise it will fail to load as the provided FreeType and SDL2 libs are too old**