### PR TITLE
Remove win_app.def from windows build

### DIFF
--- a/examples/helloworld/dub.json
+++ b/examples/helloworld/dub.json
@@ -9,8 +9,6 @@
     "targetName": "helloworld",
     "targetType": "executable",
 
-    "sourceFiles-windows": ["$PACKAGE_DIR/src/win_app.def"],
-
     "versions": ["EmbedStandardResources"],
 
     "dependencies": {


### PR DESCRIPTION
Fixes: lld-link: error: unknown directive: EXETYPE

The 
![image](https://user-images.githubusercontent.com/21064622/125165547-18155400-e1a0-11eb-9c4b-5fc96486cda0.png)
