### PR TITLE
FileDialog: Show only directories with SelectDirectory

### DIFF
--- a/src/dlangui/dialogs/filedlg.d
+++ b/src/dlangui/dialogs/filedlg.d
@@ -443,6 +443,11 @@ class FileDialog : Dialog, CustomGridCellAdapter {
         if (executableFilterSelected()) {
             attrFilter |= AttrFilter.executable;
         }
+        if (_action.id == ACTION_OPEN_DIRECTORY.id) {
+          attrFilter = AttrFilter.dirs;
+          if (showHiddenFiles)
+            attrFilter |= AttrFilter.hidden;
+        }
         try {
             _entries = listDirectory(dir, attrFilter, selectedFilter());
         } catch(Exception e) {


### PR DESCRIPTION
When a FileDialog is used to select a directory, displaying files is rather unhelpful. This commit reduces the visual clutter.

If you prefer an additional opt-in flag for this behaviour, I am willing to implement that, but I personally do not believe that there is much reason to prefer displaying files when selecting directories.