### PR TITLE
[example1/opengl] Don't enable GL_POLYGON_SMOOTH and GL_MULTISAMPLE

### DIFF
--- a/examples/example1/src/widgets/opengl.d
+++ b/examples/example1/src/widgets/opengl.d
@@ -163,9 +163,6 @@ class OpenGLExample : VerticalLayout {
             return;
         }
 
-        checkgl!glEnable(GL_MULTISAMPLE);
-        checkgl!glEnable(GL_POLYGON_SMOOTH);
-
         checkgl!glEnable(GL_CULL_FACE);
         checkgl!glEnable(GL_DEPTH_TEST);
         checkgl!glCullFace(GL_BACK);


### PR DESCRIPTION
GL_POLYGON_SMOOTH appears to have inconsistent behavior across drivers, and seems to cause issues for at least me on Linux with my graphics card.

According to Grim, it sounds like multisampling was enabled specifically for this as well, and so we no longer enable GL_MULTISAMPLE either

This fixes issue #647 