### PR TITLE
Fixed ole32.dll pragrma for cross-compilation

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -19,6 +19,8 @@
 
     "libs-linux": ["z"],
 
+    "libs-windows": ["ole32"],
+
     "stringImportPaths": [
         "views"
     ],

--- a/src/dlangui/core/files.d
+++ b/src/dlangui/core/files.d
@@ -366,7 +366,7 @@ private:
     import core.sys.windows.objbase;
     import core.sys.windows.objidl;
 
-    pragma(lib, "Ole32");
+    pragma(lib, "ole32");
 
     alias GUID KNOWNFOLDERID;
 

--- a/src/dlangui/core/files.d
+++ b/src/dlangui/core/files.d
@@ -366,8 +366,6 @@ private:
     import core.sys.windows.objbase;
     import core.sys.windows.objidl;
 
-    pragma(lib, "ole32");
-
     alias GUID KNOWNFOLDERID;
 
     extern(Windows) @nogc @system HRESULT _dummy_SHGetKnownFolderPath(const(KNOWNFOLDERID)* rfid, DWORD dwFlags, HANDLE hToken, wchar** ppszPath) nothrow;


### PR DESCRIPTION
Pragma specified Ole32.dll, which broke compilation on case-sensitive file systems, ie. when cross-compiling with ldc on Linux.

Example of the error: 

lld-link: error: could not open 'Ole32.lib': No such file or directory
Error: /usr/bin/lld-link failed with status: 1
/usr/bin/ldc2 failed with exit code 1.

This fix brings dlangui in line with other packages which pragma(lib) ole32.