### PR TITLE
Workaround bugzilla 24052 (dmd inliner slowdown)

### DIFF
--- a/src/dlangui/graphics/resources.d
+++ b/src/dlangui/graphics/resources.d
@@ -206,6 +206,11 @@ EmbeddedResource[] embedResource(string resourceName)() {
 
 /// embed all resources from list
 EmbeddedResource[] embedResources(string[] resourceNames)() {
+    version(DigitalMars)
+    {
+        pragma(inline, false); // needed because https://issues.dlang.org/show_bug.cgi?id=24052
+    }
+
     static if (resourceNames.length == 0)
         return [];
     static if (resourceNames.length == 1)


### PR DESCRIPTION
[Issue 24052](https://issues.dlang.org/show_bug.cgi?id=24052) - DMD frontend inliner causes major slowdown