### PR TITLE
Fix #645, fix #673

### DIFF
--- a/src/dlangui/widgets/editors.d
+++ b/src/dlangui/widgets/editors.d
@@ -183,10 +183,10 @@ enum EditorActions : int {
     ScrollLineUpSingle,
     /// Scroll one line down (not changing cursor)
     ScrollLineDownSingle,
-    /// Scroll one line up (not changing cursor)
-    ScrollLineUpTriple,
-    /// Scroll one line down (not changing cursor)
-    ScrollLineDownTriple,
+    /// Scroll three lines up (not changing cursor)
+    ScrollLineUp,
+    /// Scroll three lines down (not changing cursor)
+    ScrollLineDown,
     /// Scroll one page up (not changing cursor)
     ScrollPageUp,
     /// Scroll one page down (not changing cursor)
@@ -2246,13 +2246,13 @@ class EditWidgetBase : ScrollWidgetBase, EditableContentListener, MenuItemAction
                     return handleAction(new Action(EditorActions.ScrollRight));
                 if (keyFlags == MouseFlag.Control)
                     return handleAction(new Action(EditorActions.ZoomOut));
-                return handleAction(new Action(EditorActions.ScrollLineDownTriple));
+                return handleAction(new Action(EditorActions.ScrollLineDown));
             } else if (event.wheelDelta > 0) {
                 if (keyFlags == MouseFlag.Shift)
                     return handleAction(new Action(EditorActions.ScrollLeft));
                 if (keyFlags == MouseFlag.Control)
                     return handleAction(new Action(EditorActions.ZoomIn));
-                return handleAction(new Action(EditorActions.ScrollLineUpTriple));
+                return handleAction(new Action(EditorActions.ScrollLineUp));
             }
         }
         cancelHoverTimer();
@@ -3238,10 +3238,10 @@ class EditBox : EditWidgetBase {
                     }
                 }
                 return true;
-            case ScrollLineUpSingle:
+            case ScrollLineUp:
                 {
                     if (_firstVisibleLine > 0) {
-                        _firstVisibleLine -= 1;
+                        _firstVisibleLine -= 3;
                         if (_firstVisibleLine < 0)
                             _firstVisibleLine = 0;
                         measureVisibleText();
@@ -3250,10 +3250,10 @@ class EditBox : EditWidgetBase {
                     }
                 }
                 return true;
-            case ScrollLineUpTriple:
+            case ScrollLineUpSingle:
                 {
                     if (_firstVisibleLine > 0) {
-                        _firstVisibleLine -= 3;
+                        _firstVisibleLine -= 1;
                         if (_firstVisibleLine < 0)
                             _firstVisibleLine = 0;
                         measureVisibleText();
@@ -3275,11 +3275,11 @@ class EditBox : EditWidgetBase {
                     }
                 }
                 return true;
-            case ScrollLineDownSingle:
+            case ScrollLineDown:
                 {
                     int fullLines = _clientRect.height / _lineHeight;
                     if (_firstVisibleLine + fullLines < _content.length) {
-                        _firstVisibleLine += 1;
+                        _firstVisibleLine += 3;
                         if (_firstVisibleLine > _content.length - fullLines)
                             _firstVisibleLine = _content.length - fullLines;
                         if (_firstVisibleLine < 0)
@@ -3290,11 +3290,11 @@ class EditBox : EditWidgetBase {
                     }
                 }
                 return true;
-            case ScrollLineDownTriple:
+            case ScrollLineDownSingle:
                 {
                     int fullLines = _clientRect.height / _lineHeight;
                     if (_firstVisibleLine + fullLines < _content.length) {
-                        _firstVisibleLine += 3;
+                        _firstVisibleLine += 1;
                         if (_firstVisibleLine > _content.length - fullLines)
                             _firstVisibleLine = _content.length - fullLines;
                         if (_firstVisibleLine < 0)

--- a/src/dlangui/widgets/tabs.d
+++ b/src/dlangui/widgets/tabs.d
@@ -475,7 +475,7 @@ class TabControl : WidgetGroupDefaultDrawing {
     }
 
     /// change name of tab
-    void renameTab(string ID, dstring name) {
+    void renameTab(string id, dstring name) {
         int index = _items.indexById(id);
         if (index >= 0) {
             renameTab(index, name);


### PR DESCRIPTION
Fix #673 where the function `renameTab(string ID, dstring name)` in `src/dlangui/widgets/tabs.d` failed to find the tab with the given id because it uses the `TabControl`'s own id due to the misuse of lower/upper case names. Changed the function's argument `ID` that have never been used to `id`.  
  
Fix #645 where `EditWidgetBase` doesn't scroll when mouse selection is active and the cursor goes beyond the widget boundaries. Now it scrolls.   Additionally, added new type of `EditorActions` to make 2 different types of `EditorActions.ScrollLineUp/Down`. The old `ScrollLineUp/Down` made 3 lines scrolling and it doesn't work well with new mouse selection scrolling when out of bounds (scrolls too fast). So now there are `ScrollLineUp/DownSingle` and `ScrollLineUp/DownTriple`. The single one is used by the mouse selection scrolling, the triple one used in all other cases just like before.