### PR TITLE
Enable mouse event processing for ListWidget adapter children

### DIFF
--- a/src/dlangui/widgets/lists.d
+++ b/src/dlangui/widgets/lists.d
@@ -1358,7 +1358,7 @@ class ListWidget : WidgetGroup, OnScrollHandler, OnAdapterChangeHandler {
                         if (event.action == MouseAction.Move && event.noModifiers && itemWidget.hasTooltip) {
                             itemWidget.scheduleTooltip(200);
                         }
-                        //itemWidget.onMouseEvent(event);
+                        itemWidget.onMouseEvent(event);
                         itemWidget.parent = oldParent;
                     }
                 }


### PR DESCRIPTION
Fixes #538 

Disclaimer:
1) I only checked it with mouse events, not keyboard events
2) Git history shows that this line was never uncommented, it was added in b07d0aae already commented out. The commit was introduced in https://github.com/buggins/dlangui/issues/303. There, @buggins [states](https://github.com/buggins/dlangui/issues/303#issuecomment-253817578): "_No mouse events are being passed to items in list widget. List handles them all._". I examined `widget.d` and see that it's only partially true. `ListWidget` indeed manages its children hover/selected state, but that's it. There are use cases when it's not enough, e.g. I want to open a popup menu by right-clicking a `ListWidget` child added through `adapter`. 

Uncommenting the line fixes the issue for me and looks like a straingtforward thing to do, but then again I don't know what was @buggins ' motivation and design goals there. So, proceed with caution